### PR TITLE
ci: harden hosted project validation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @garethpaul

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Run static project baseline
         run: make check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md
+
+## Repository purpose
+
+`garethpaul/gameofthrows` is a preserved Swift 2 and SpriteKit iOS 9 sample
+inspired by Flappy Bird. It includes a small UI launch test and a static
+maintenance baseline for the legacy Xcode project.
+
+## Project structure
+
+- `Makefile` - repository verification targets
+- `scripts` - baseline checks and helper scripts
+- `docs` - plans, notes, and generated README assets
+- `GameOfThrows.xcodeproj` - Xcode project
+- `GameOfThrows` - repository source or sample assets
+- `GameOfThrowsUITests` - repository source or sample assets
+
+## Development commands
+
+- Install dependencies: no repository-specific install command is documented.
+- Full baseline: `make check`
+- Lint/static checks: `make lint`
+- Tests: `make test`
+- Build gate: `make build`
+- Local Apple development: `open GameOfThrows.xcodeproj`
+- If a command above skips because a platform toolchain is missing, verify on a machine with that SDK before claiming platform behavior is tested.
+
+## Coding conventions
+
+- Preserve the Swift 2 syntax and SpriteKit APIs unless modernization is the
+  explicit task and is verified with a compatible Xcode toolchain.
+- Preserve legacy Xcode project settings and signing assumptions unless the change is explicitly about modernization.
+
+## Testing guidance
+
+- Test-related files detected: `GameOfThrows.xcodeproj/xcshareddata/xcschemes/GameOfThrowsUITests.xcscheme`, `GameOfThrowsUITests/GameOfThrowsUITests.swift`
+- Hosted macOS CI runs `make check` and parses the Xcode project; it does not
+  select a simulator, launch the app, or exercise gameplay.
+- Start with the narrowest relevant test or Make target, then run `make check` before handing off if the change is not documentation-only.
+- Keep README verification notes in sync when commands, fixtures, or supported toolchains change.
+
+## PR / change guidance
+
+- Keep diffs focused on the requested repository and avoid unrelated modernization or formatting churn.
+- Preserve public APIs, sample behavior, file formats, and documented environment variables unless the task explicitly changes them.
+- Update tests, README notes, or docs/plans when behavior, security posture, or validation commands change.
+- Call out skipped platform validation, legacy toolchain assumptions, and any risky files touched in the final summary.
+
+## Safety and gotchas
+
+- No required secret or credential file was identified in the repository scan. If you add integrations later, keep secrets out of git.
+- This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
+- Keep the checkout action pinned, read-only, and configured without persisted
+  credentials; keep `check.yml` as the only hosted workflow unless the baseline
+  and documentation intentionally change with it.
+- Keep repeating SpriteKit actions weakly captured and remove scene actions and
+  contact callbacks when a scene leaves its view.
+- Run `make lint`, `make test`, `make build`, and `make check` before pushing changes that touch SpriteKit scene loading, assets, build scripts, project files, or UI test setup.
+- See `SECURITY.md` for vulnerability reporting and safe research guidance.
+- See `VISION.md` for project direction and contribution guardrails.
+- See `docs/plans/2026-06-09-single-tap-impulse-guard.md` for the tap impulse guard.
+
+## Agent workflow
+
+1. Inspect the README, Makefile, manifests, and the files directly related to the request.
+2. Make the smallest source or docs change that satisfies the task; avoid generated, vendored, or local-environment files unless required.
+3. Run the narrowest useful validation first, then `make check` or the documented package/platform gate when available.
+4. If a required SDK, service credential, or external runtime is unavailable, record the skipped command and why.
+5. Summarize changed files, commands run, and remaining risks or follow-up validation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 2026-06-12
+
+- Preserved repository-specific agent instructions for the legacy Swift and
+  SpriteKit maintenance workflow.
+- Pinned checkout to the immutable v6.0.3 commit, disabled persisted checkout
+  credentials, assigned repository ownership, and made the local baseline
+  reject hidden workflows or any drift from the canonical hosted job.
+
 ## 2026-06-10
 
 - Prevented the repeating pipe-spawn action from retaining inactive scenes and

--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Run `./build.sh` on macOS with Xcode installed. Set `IOS_SIMULATOR_NAME` to
   override only the simulator name, or `IOS_DESTINATION` to provide a full
   xcodebuild destination string.
-- GitHub Actions runs `make check` on macOS and parses the Xcode project without
-  selecting an obsolete simulator. Run `build.sh` explicitly for UI testing.
+- GitHub Actions runs `make check` on macOS with read-only permissions, an
+  immutable checkout action, and `persist-credentials: false`. It parses the
+  Xcode project without selecting an obsolete simulator. Run `build.sh`
+  explicitly for UI testing.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.
 
@@ -97,6 +99,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 - See `docs/plans/2026-06-10-hosted-project-validation.md` for the hosted Xcode
   project parsing boundary.
+- See `docs/plans/2026-06-12-ci-policy-hardening.md` for the canonical hosted
+  workflow and hostile-mutation boundary.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing
   changes that touch SpriteKit scene loading, assets, build scripts, project

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,8 @@ teardown should remove pending actions and physics contact callbacks.
 
 GitHub Actions runs the static resource and crash guardrails plus an Xcode
 project parse with read-only repository permissions before changes land.
+The workflow uses an immutable checkout action without persisted credentials,
+and the local baseline rejects extra workflows or canonical job-shape drift.
 
 Dependency updates should come from trusted package managers and should keep lockfiles in sync when lockfiles exist. Do not commit credentials, private keys, tokens, generated secrets, or machine-local configuration. If a vulnerability depends on a compromised package, typosquatting risk, insecure transitive dependency, or unsafe build step, include the package name, affected version, and the path through which it is used.
 

--- a/VISION.md
+++ b/VISION.md
@@ -74,6 +74,8 @@ Next priorities:
   action-driven
 - Keep local verification targets available even while full Xcode execution
   needs a macOS toolchain
+- Keep hosted validation to one bounded, read-only workflow with an immutable
+  checkout action and no persisted checkout credentials
 - Keep touch, contact, and spawn decisions routed through the active-gameplay
   guard while movement state remains an implicitly unwrapped scene node
 - Keep repeating action ownership weak and scene teardown explicit

--- a/docs/plans/2026-06-12-ci-policy-hardening.md
+++ b/docs/plans/2026-06-12-ci-policy-hardening.md
@@ -1,0 +1,34 @@
+---
+title: Harden hosted workflow policy
+status: completed
+date: 2026-06-12
+---
+
+# Harden hosted workflow policy
+
+## Goal
+
+Keep the legacy SpriteKit sample's hosted validation bounded, reproducible, and
+unable to expose the checkout credential to later steps.
+
+## Changes
+
+- Pin `actions/checkout` to the immutable v6.0.3 commit.
+- Set `persist-credentials: false` and retain repository-wide read-only
+  permissions.
+- Keep `check.yml` as the only hosted workflow.
+- Compare the entire workflow against one canonical definition so duplicate
+  jobs, extra actions, conditionals, permission overrides, or alternate commands
+  cannot bypass the local policy.
+- Assign repository-wide review ownership in `.github/CODEOWNERS`.
+
+## Verification
+
+- `make check`
+- `make lint`
+- `make test`
+- `make build`
+- `git diff --check`
+- Isolated hostile workflow mutations covering persisted credentials, extra
+  steps, duplicate permissions, mutable action references, and hidden workflow
+  files; every mutation must fail.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -14,6 +14,7 @@ RESTART_RESOURCE_PLAN="$ROOT_DIR/docs/plans/2026-06-09-restart-resource-guard.md
 CONTACT_RESOURCE_PLAN="$ROOT_DIR/docs/plans/2026-06-09-contact-resource-guard.md"
 CI_PLAN="$ROOT_DIR/docs/plans/2026-06-10-hosted-project-validation.md"
 SCENE_LIFECYCLE_PLAN="$ROOT_DIR/docs/plans/2026-06-10-scene-action-lifecycle.md"
+CI_POLICY_PLAN="$ROOT_DIR/docs/plans/2026-06-12-ci-policy-hardening.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -25,8 +26,10 @@ require_file() {
 }
 
 for path in \
+  ".github/CODEOWNERS" \
   ".github/workflows/check.yml" \
   ".gitignore" \
+  "AGENTS.md" \
   "CHANGES.md" \
   "Makefile" \
   "README.md" \
@@ -51,7 +54,8 @@ for path in \
   "docs/plans/2026-06-09-single-tap-impulse-guard.md" \
   "docs/plans/2026-06-09-score-contact-idempotency.md" \
   "docs/plans/2026-06-10-hosted-project-validation.md" \
-  "docs/plans/2026-06-10-scene-action-lifecycle.md"; do
+  "docs/plans/2026-06-10-scene-action-lifecycle.md" \
+  "docs/plans/2026-06-12-ci-policy-hardening.md"; do
   require_file "$path"
 done
 
@@ -323,13 +327,49 @@ else
   printf '%s\n' "xcodebuild not found; static GameOfThrows baseline checks passed."
 fi
 
-if ! grep -Fq "contents: read" "$CI_WORKFLOW" ||
-  ! grep -Fq "cancel-in-progress: true" "$CI_WORKFLOW" ||
-  ! grep -Fq "runs-on: macos-15" "$CI_WORKFLOW" ||
-  ! grep -Fq "timeout-minutes: 10" "$CI_WORKFLOW" ||
-  ! grep -Fq "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" "$CI_WORKFLOW" ||
-  ! grep -Fq "run: make check" "$CI_WORKFLOW"; then
-  printf '%s\n' "GitHub Actions must keep the bounded, least-privilege macOS project check." >&2
+workflow_files=$(find "$ROOT_DIR/.github/workflows" -type f -print)
+if [ "$workflow_files" != "$CI_WORKFLOW" ]; then
+  printf '%s\n' "check.yml must remain the only hosted workflow." >&2
+  exit 1
+fi
+
+expected_workflow=$(mktemp "${TMPDIR:-/tmp}/gameofthrows-check.XXXXXX")
+trap 'rm -f "$expected_workflow"' EXIT HUP INT TERM
+cat >"$expected_workflow" <<'EOF'
+name: Check
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: macos-15
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Run static project baseline
+        run: make check
+EOF
+
+if ! cmp -s "$expected_workflow" "$CI_WORKFLOW"; then
+  printf '%s\n' "GitHub Actions must match the canonical bounded, credential-free macOS check." >&2
+  exit 1
+fi
+
+if [ "$(cat "$ROOT_DIR/.github/CODEOWNERS")" != "* @garethpaul" ]; then
+  printf '%s\n' "CODEOWNERS must assign repository-wide ownership." >&2
   exit 1
 fi
 
@@ -342,5 +382,12 @@ fi
 if ! grep -Fq "status: completed" "$SCENE_LIFECYCLE_PLAN" ||
   ! grep -Fq "Mutations restoring strong spawn capture or removing teardown must fail" "$SCENE_LIFECYCLE_PLAN"; then
   printf '%s\n' "Scene action lifecycle plan must record completed mutation verification." >&2
+  exit 1
+fi
+
+if ! grep -Fq "status: completed" "$CI_POLICY_PLAN" ||
+  ! grep -Fq "persist-credentials: false" "$CI_POLICY_PLAN" ||
+  ! grep -Fq "hostile workflow mutations" "$CI_POLICY_PLAN"; then
+  printf '%s\n' "CI policy hardening plan must record completed mutation verification." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- preserve repository-specific maintenance instructions for the legacy Swift 2 and SpriteKit sample
- pin checkout to the immutable v6.0.3 commit and disable persisted checkout credentials
- enforce one canonical read-only macOS workflow, reject hidden workflow drift, and assign repository-wide ownership

## Testing

- `make check`
- `make lint`
- `make test`
- `make build`
- `sh -n scripts/check-baseline.sh`
- `sh -n build.sh`
- `git diff --check origin/master...HEAD`
- 7 isolated hostile workflow mutations rejected

## Review

- Compound Engineering correctness, testing, maintainability, project-standards, security, and Swift/iOS review
- final review: no actionable findings

## Limits

- local validation skipped `xcodebuild` because this Linux environment does not provide Xcode
- hosted macOS validation parses the project but does not launch a simulator or exercise gameplay
