### PR TITLE
fix: remove dangling scheme test target

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-12
 
+- Removed the app scheme's dangling `GameOfThrowsTests` reference and made the
+  baseline reject shared-scheme target identifiers missing from the project.
 - Preserved repository-specific agent instructions for the legacy Swift and
   SpriteKit maintenance workflow.
 - Pinned checkout to the immutable v6.0.3 commit, disabled persisted checkout

--- a/GameOfThrows.xcodeproj/xcshareddata/xcschemes/GameOfThrows.xcscheme
+++ b/GameOfThrows.xcodeproj/xcshareddata/xcschemes/GameOfThrows.xcscheme
@@ -32,16 +32,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4374520F193D163800654986"
-               BuildableName = "GameOfThrowsTests.xctest"
-               BlueprintName = "GameOfThrowsTests"
-               ReferencedContainer = "container:GameOfThrows.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "7FD1E5A81D27795A00FB1662"
                BuildableName = "GameOfThrowsUITests.xctest"
                BlueprintName = "GameOfThrowsUITests"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   work and avoids delayed `self.bird` access after a crash contact.
 - The repeating spawn action uses a weak scene capture and is removed with
   pending flash work when the scene leaves its SpriteKit view.
+- Shared schemes may reference only targets present in `project.pbxproj`; the
+  app scheme runs the existing UI launch test without the removed unit-test
+  bundle.
 - Xcode's test action or `xcodebuild test` with the appropriate scheme and destination
 - Run `./build.sh` on macOS with Xcode installed. Set `IOS_SIMULATOR_NAME` to
   override only the simulator name, or `IOS_DESTINATION` to provide a full
@@ -101,6 +104,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   project parsing boundary.
 - See `docs/plans/2026-06-12-ci-policy-hardening.md` for the canonical hosted
   workflow and hostile-mutation boundary.
+- See `docs/plans/2026-06-12-shared-scheme-target-integrity.md` for shared
+  scheme target validation.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing
   changes that touch SpriteKit scene loading, assets, build scripts, project

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,8 @@ GitHub Actions runs the static resource and crash guardrails plus an Xcode
 project parse with read-only repository permissions before changes land.
 The workflow uses an immutable checkout action without persisted credentials,
 and the local baseline rejects extra workflows or canonical job-shape drift.
+Shared Xcode schemes must reference only targets defined by the checked-in
+project so stale test entries cannot bypass the intended launch-test contract.
 
 Dependency updates should come from trusted package managers and should keep lockfiles in sync when lockfiles exist. Do not commit credentials, private keys, tokens, generated secrets, or machine-local configuration. If a vulnerability depends on a compromised package, typosquatting risk, insecure transitive dependency, or unsafe build step, include the package name, affected version, and the path through which it is used.
 

--- a/VISION.md
+++ b/VISION.md
@@ -56,6 +56,8 @@ Current baseline:
 - The local Makefile exposes lint, test, build, and check targets for a stable
   pre-push gate.
 - UI tests keep a launch smoke test for basic app startup coverage.
+- Shared scheme BlueprintIdentifiers are validated against the Xcode project,
+  and the app scheme contains only the existing UI-test bundle.
 
 Next priorities:
 
@@ -79,6 +81,7 @@ Next priorities:
 - Keep touch, contact, and spawn decisions routed through the active-gameplay
   guard while movement state remains an implicitly unwrapped scene node
 - Keep repeating action ownership weak and scene teardown explicit
+- Keep shared schemes free of dangling project target references
 - Modernize Swift/project settings in a dedicated pass
 
 Contribution rules:

--- a/docs/plans/2026-06-12-shared-scheme-target-integrity.md
+++ b/docs/plans/2026-06-12-shared-scheme-target-integrity.md
@@ -1,0 +1,53 @@
+# Shared Scheme Target Integrity
+
+status: planned
+
+## Context
+
+`GameOfThrows.xcscheme` includes a testable reference to
+`GameOfThrowsTests.xctest` with BlueprintIdentifier `4374520F193D163800654986`.
+That target no longer exists in `project.pbxproj`; the project contains only the
+application and UI-test targets.
+
+The hosted baseline parses the project with `xcodebuild -list`, but the local
+static checks do not verify that every target referenced by a shared scheme is
+still defined by the project. A stale test reference can therefore break the
+scheme's Test action while the current gate remains green.
+
+## Priority
+
+Shared schemes are the checked-in build and test contract for contributors and
+automation. Dangling BlueprintIdentifiers make that contract misleading and
+can fail before the remaining launch test runs.
+
+## Prioritized Backlog
+
+1. Remove the orphaned `GameOfThrowsTests` entry from the app scheme.
+2. Keep the existing `GameOfThrowsUITests` testable reference intact.
+3. Make the static baseline reject every shared-scheme BlueprintIdentifier that
+   is absent from `project.pbxproj`.
+4. Document the repaired scheme contract and compatible-Xcode verification
+   requirement.
+
+## Implementation
+
+- Edit only the stale `TestableReference` in `GameOfThrows.xcscheme`.
+- Extract BlueprintIdentifiers from all checked-in shared schemes and require
+  each identifier to appear in the Xcode project.
+- Require the app scheme to retain the UI-test bundle reference and reject the
+  removed legacy unit-test bundle name.
+- Extend README, SECURITY, VISION, CHANGES, and the repository baseline.
+
+## Verification
+
+- `make check`
+- `make lint`
+- `make test`
+- `make build`
+- `sh -n scripts/check-baseline.sh`
+- Parse both shared schemes as XML.
+- `git diff --check`
+- Mutations restoring the orphaned target or replacing a valid BlueprintIdentifier
+  with an unknown value must fail.
+- Run the scheme Test action on a compatible Xcode and iOS simulator before
+  claiming runtime gameplay coverage.

--- a/docs/plans/2026-06-12-shared-scheme-target-integrity.md
+++ b/docs/plans/2026-06-12-shared-scheme-target-integrity.md
@@ -1,12 +1,12 @@
 # Shared Scheme Target Integrity
 
-status: planned
+status: completed
 
 ## Context
 
-`GameOfThrows.xcscheme` includes a testable reference to
+`GameOfThrows.xcscheme` included a testable reference to
 `GameOfThrowsTests.xctest` with BlueprintIdentifier `4374520F193D163800654986`.
-That target no longer exists in `project.pbxproj`; the project contains only the
+That target does not exist in `project.pbxproj`; the project contains only the
 application and UI-test targets.
 
 The hosted baseline parses the project with `xcodebuild -list`, but the local

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -15,7 +15,11 @@ CONTACT_RESOURCE_PLAN="$ROOT_DIR/docs/plans/2026-06-09-contact-resource-guard.md
 CI_PLAN="$ROOT_DIR/docs/plans/2026-06-10-hosted-project-validation.md"
 SCENE_LIFECYCLE_PLAN="$ROOT_DIR/docs/plans/2026-06-10-scene-action-lifecycle.md"
 CI_POLICY_PLAN="$ROOT_DIR/docs/plans/2026-06-12-ci-policy-hardening.md"
+SCHEME_TARGET_PLAN="$ROOT_DIR/docs/plans/2026-06-12-shared-scheme-target-integrity.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
+PROJECT_FILE="$ROOT_DIR/GameOfThrows.xcodeproj/project.pbxproj"
+SHARED_SCHEMES="$ROOT_DIR/GameOfThrows.xcodeproj/xcshareddata/xcschemes"
+APP_SCHEME="$SHARED_SCHEMES/GameOfThrows.xcscheme"
 
 require_file() {
   path=$1
@@ -38,6 +42,8 @@ for path in \
   "build.sh" \
   "GameOfThrows/Info.plist" \
   "GameOfThrows.xcodeproj/project.pbxproj" \
+  "GameOfThrows.xcodeproj/xcshareddata/xcschemes/GameOfThrows.xcscheme" \
+  "GameOfThrows.xcodeproj/xcshareddata/xcschemes/GameOfThrowsUITests.xcscheme" \
   "GameOfThrows/GameScene.swift" \
   "GameOfThrows/GameViewController.swift" \
   "GameOfThrows/AppDelegate.swift" \
@@ -55,7 +61,8 @@ for path in \
   "docs/plans/2026-06-09-score-contact-idempotency.md" \
   "docs/plans/2026-06-10-hosted-project-validation.md" \
   "docs/plans/2026-06-10-scene-action-lifecycle.md" \
-  "docs/plans/2026-06-12-ci-policy-hardening.md"; do
+  "docs/plans/2026-06-12-ci-policy-hardening.md" \
+  "docs/plans/2026-06-12-shared-scheme-target-integrity.md"; do
   require_file "$path"
 done
 
@@ -208,6 +215,26 @@ fi
 
 if ! grep -Fq "GameOfThrowsUITests" "$ROOT_DIR/GameOfThrows.xcodeproj/project.pbxproj"; then
   printf '%s\n' "Xcode project must include the UI test target." >&2
+  exit 1
+fi
+
+native_target_ids=$(sed -n '/Begin PBXNativeTarget section/,/End PBXNativeTarget section/ {
+  s/^[[:space:]]*\([A-F0-9]\{24\}\) \/\*.*/\1/p
+}' "$PROJECT_FILE")
+
+for scheme in "$SHARED_SCHEMES"/*.xcscheme; do
+  blueprint_ids=$(sed -n 's/.*BlueprintIdentifier = "\([^"]*\)".*/\1/p' "$scheme")
+  for blueprint_id in $blueprint_ids; do
+    if ! printf '%s\n' "$native_target_ids" | grep -Fxq "$blueprint_id"; then
+      printf '%s\n' "Shared scheme references missing project target $blueprint_id: $scheme" >&2
+      exit 1
+    fi
+  done
+done
+
+if grep -Fq "GameOfThrowsTests.xctest" "$APP_SCHEME" ||
+  ! grep -Fq "GameOfThrowsUITests.xctest" "$APP_SCHEME"; then
+  printf '%s\n' "App scheme must retain the UI test target without the removed unit test target." >&2
   exit 1
 fi
 
@@ -382,6 +409,12 @@ fi
 if ! grep -Fq "status: completed" "$SCENE_LIFECYCLE_PLAN" ||
   ! grep -Fq "Mutations restoring strong spawn capture or removing teardown must fail" "$SCENE_LIFECYCLE_PLAN"; then
   printf '%s\n' "Scene action lifecycle plan must record completed mutation verification." >&2
+  exit 1
+fi
+
+if ! grep -Fq "status: completed" "$SCHEME_TARGET_PLAN" ||
+  ! grep -Fq "Mutations restoring the orphaned target" "$SCHEME_TARGET_PLAN"; then
+  printf '%s\n' "Shared scheme target-integrity plan must record completed mutation verification." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- remove the stale `GameOfThrowsTests` entry from the shared app scheme
- preserve the existing UI launch-test target
- validate every shared-scheme BlueprintIdentifier against actual `PBXNativeTarget` declarations
- document the repaired scheme contract and compatible-Xcode limitation

## Validation

- `make check`
- `make lint`
- `make test`
- `make build`
- `sh -n scripts/check-baseline.sh`
- `sh -n build.sh`
- both shared schemes parsed as XML with Ruby REXML
- `git diff --check`
- orphaned-target mutation: rejected
- unknown-target mutation: rejected
- existing non-target project identifier mutation: rejected

`xcodebuild test` was not run locally because this Linux host has no Xcode or iOS simulator. Hosted macOS validation still parses the checked-in project.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
