### PR TITLE
docs: record scheme repair verification

### DIFF
--- a/docs/plans/2026-06-12-shared-scheme-target-integrity.md
+++ b/docs/plans/2026-06-12-shared-scheme-target-integrity.md
@@ -51,3 +51,27 @@ can fail before the remaining launch test runs.
   with an unknown value must fail.
 - Run the scheme Test action on a compatible Xcode and iOS simulator before
   claiming runtime gameplay coverage.
+
+## Work Completed
+
+- Removed the orphaned `GameOfThrowsTests.xctest` reference while retaining
+  the valid `GameOfThrowsUITests.xctest` reference in the shared app scheme.
+- Added a static contract that resolves every shared-scheme
+  `BlueprintIdentifier` against the native targets declared by
+  `project.pbxproj`.
+- Kept the compatible-Xcode requirement explicit so static project validation
+  cannot be mistaken for runtime gameplay coverage.
+
+## Verification Completed
+
+- `make lint`, `make test`, `make build`, `make check`, shell syntax, both
+  shared-scheme XML parses, and `git diff --check` passed locally. The local
+  environment lacks Xcode, so this evidence is limited to the static baseline.
+- Implementation push run `27392844491` and pull-request run `27392848940`
+  passed at commit `e32d324639738acc6aaf2e8fcd2719a9704aa903`; the hosted
+  macOS gate included `xcodebuild -list` project parsing.
+- Post-merge push run `27392863018` and CodeQL run `27402320931` passed at
+  default-branch merge commit `e0361e43735db41c9ebaff1d167f8b451506f7d4`.
+- Mutations restoring the orphaned target or replacing a valid
+  `BlueprintIdentifier` with an unknown target were rejected by `make check`.
+  No simulator Test action or runtime gameplay coverage is claimed.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -412,11 +412,34 @@ if ! grep -Fq "status: completed" "$SCENE_LIFECYCLE_PLAN" ||
   exit 1
 fi
 
-if ! grep -Fq "status: completed" "$SCHEME_TARGET_PLAN" ||
-  ! grep -Fq "Mutations restoring the orphaned target" "$SCHEME_TARGET_PLAN"; then
-  printf '%s\n' "Shared scheme target-integrity plan must record completed mutation verification." >&2
-  exit 1
-fi
+python3 - "$SCHEME_TARGET_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+statuses = re.findall(r"^status: .+$", plan, flags=re.MULTILINE)
+parts = plan.split("## Verification Completed\n", 1)
+verification = parts[1] if len(parts) == 2 else ""
+required = (
+    "`make lint`, `make test`, `make build`, `make check`",
+    "push run `27392844491`",
+    "pull-request run `27392848940`",
+    "push run `27392863018`",
+    "CodeQL run `27402320931`",
+    "Mutations restoring the orphaned target",
+    "No simulator Test action or runtime gameplay coverage is claimed.",
+)
+
+if (
+    statuses != ["status: completed"]
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Shared scheme target-integrity plan must remain completed with actual verification recorded."
+    )
+PY
 
 if ! grep -Fq "status: completed" "$CI_POLICY_PLAN" ||
   ! grep -Fq "persist-credentials: false" "$CI_POLICY_PLAN" ||


### PR DESCRIPTION
## Summary

- record the completed shared-scheme target repair with exact local and hosted evidence
- distinguish static project validation from unclaimed simulator gameplay coverage
- make the baseline require section-specific completion evidence and exact canonical run IDs

## Baseline

The pre-change constraints and motivation are captured in the Summary and existing supporting sections.

## Improvements

The implemented changes are captured in the Summary and existing supporting sections.

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- `sh -n scripts/check-baseline.sh`
- parsed both shared schemes as XML
- `git diff --check`
- five hostile mutations rejected: stale status, placeholder evidence, falsified run ID, restored orphan target, and unknown target identifier

## Risk

Documentation and baseline-checker only. Runtime SpriteKit behavior and Xcode project contents are unchanged.

## Follow-Ups

No additional follow-up is introduced by this description-only normalization; existing monitoring and remaining-work notes remain authoritative.
