### PR TITLE
fix: make scene presentation idempotent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ maintenance baseline for the legacy Xcode project.
   and documentation intentionally change with it.
 - Keep repeating SpriteKit actions weakly captured and remove scene actions and
   contact callbacks when a scene leaves its view.
+- Clear prior keyed actions and child nodes before rebuilding a presented scene.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes that touch SpriteKit scene loading, assets, build scripts, project files, or UI test setup.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made repeated scene presentation clear prior keyed actions and child nodes
+  before rebuilding the gameplay graph.
 - Required explicit bird-world or bird-pipe pairing before contact handling can
   stop gameplay, leaving unrelated physics contacts without side effects.
 

--- a/GameOfThrows/GameScene.swift
+++ b/GameOfThrows/GameScene.swift
@@ -22,8 +22,15 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
     let worldCategory: UInt32 = 1 << 1
     let pipeCategory: UInt32 = 1 << 2
     let scoreCategory: UInt32 = 1 << 3
+
+    func resetScenePresentation() {
+        self.removeActionForKey("spawnPipes")
+        self.removeActionForKey("flash")
+        self.removeAllChildren()
+    }
     
     override func didMoveToView(view: SKView) {
+        resetScenePresentation()
         
         canRestart = false
         

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   work and avoids delayed `self.bird` access after a crash contact.
 - The repeating spawn action uses a weak scene capture and is removed with
   pending flash work when the scene leaves its SpriteKit view.
+- Scene presentation clears prior keyed actions and child nodes before rebuilding gameplay,
+  preventing duplicate physics and rendering graphs when a scene is presented again.
 - Shared schemes may reference only targets present in `project.pbxproj`; the
   app scheme runs the existing UI launch test without the removed unit-test
   bundle.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,8 @@ Only explicit bird-world or bird-pipe contacts should trigger game-over;
 unrelated sensor contacts should not mutate movement or restart state.
 Repeating SpriteKit actions should not retain scenes after presentation ends;
 teardown should remove pending actions and physics contact callbacks.
+Scene presentation should clear prior keyed actions and child nodes before rebuilding gameplay
+so stale physics bodies cannot remain active after re-presentation.
 
 ## Dependency and Supply Chain Security
 

--- a/VISION.md
+++ b/VISION.md
@@ -53,6 +53,8 @@ Current baseline:
   resources so stopped gameplay does not keep adding pipe pairs.
 - Touch, contact, and pipe spawning paths share an active-gameplay guard before
   reading movement state.
+- Scene presentation clears prior keyed actions and child nodes before rebuilding gameplay,
+  keeping repeated presentation from duplicating interactive scene state.
 - The scene tears down repeating actions and its physics contact delegate when
   it leaves the SpriteKit view; the spawn closure does not retain the scene.
 - The local Makefile exposes lint, test, build, and check targets for a stable

--- a/docs/plans/2026-06-13-scene-presentation-idempotency.md
+++ b/docs/plans/2026-06-13-scene-presentation-idempotency.md
@@ -1,7 +1,7 @@
 ---
 title: Idempotent Scene Presentation
 date: 2026-06-13
-status: planned
+status: completed
 execution: code
 ---
 
@@ -53,8 +53,24 @@ preserving the current first-presentation behavior.
 
 ## Work Completed
 
-- Pending implementation.
+- Added a scene-presentation reset helper that removes the pipe-spawn and flash
+  actions plus the prior child graph.
+- Ran the reset before `didMoveToView` initializes gameplay state or inserts any
+  replacement nodes.
+- Added static helper-content, invocation-count, setup-order, documentation,
+  and completed-plan contracts.
+- Documented the repeated-presentation boundary in project guidance and change
+  history.
 
 ## Verification Completed
 
-- Pending implementation and verification.
+- A pristine copied tree passed `make check` with completed-plan evidence
+  supplied in the copy.
+- The presentation reset mutation failed after removing the cleanup call from
+  `didMoveToView`.
+- The child cleanup mutation failed after removing `removeAllChildren()` from
+  the reset helper.
+- The setup ordering mutation failed after moving cleanup below initial gameplay
+  state setup.
+- The hosted pull-request check is a post-push evidence step; its bounded
+  exact-head result is recorded after the implementation commit is pushed.

--- a/docs/plans/2026-06-13-scene-presentation-idempotency.md
+++ b/docs/plans/2026-06-13-scene-presentation-idempotency.md
@@ -1,0 +1,60 @@
+---
+title: Idempotent Scene Presentation
+date: 2026-06-13
+status: planned
+execution: code
+---
+
+## Context
+
+`didMoveToView` builds the complete gameplay node graph every time SpriteKit
+presents the scene. `willMoveFromView` stops scene actions and contact callbacks,
+but it leaves the previous bird, ground, moving graph, pipes, and score label in
+place. Presenting the same `GameScene` instance again therefore appends duplicate
+gameplay nodes and leaves stale child actions running beside the new graph.
+
+## Priority
+
+This is the highest-value remaining isolated lifecycle guard because scene
+presentation owns every visible and interactive gameplay node. Making that
+boundary idempotent prevents duplicated physics bodies and rendering work while
+preserving the current first-presentation behavior.
+
+## Prioritized Backlog
+
+1. Clear prior scene-owned keyed actions before rebuilding the scene.
+2. Remove the prior child graph before adding the new moving graph and gameplay
+   nodes.
+3. Preserve first presentation, teardown, collision, scoring, and restart
+   behavior.
+4. Add source-order and hostile-mutation contracts plus repository guidance.
+5. Keep runtime re-presentation coverage and Swift modernization as separate
+   work requiring a compatible legacy simulator toolchain.
+
+## Implementation
+
+- Add a small scene-presentation reset helper that removes the `spawnPipes` and
+  `flash` actions and clears existing children.
+- Call the helper at the start of `didMoveToView`, before any gameplay node is
+  created.
+- Extend the static baseline to require the cleanup operations and their order
+  relative to scene reconstruction.
+- Update README, SECURITY, VISION, CHANGES, and AGENTS guidance with the
+  re-presentation boundary.
+
+## Verification Plan
+
+- Run shell syntax, all four Make gates, plist/project/workspace parsing,
+  `git diff --check`, and intended-file secret checks.
+- Remove the presentation reset call, omit child removal, and move cleanup after
+  the first child insertion; each hostile mutation must fail.
+- Take one bounded exact-head pull-request and CodeQL snapshot after push; do
+  not poll.
+
+## Work Completed
+
+- Pending implementation.
+
+## Verification Completed
+
+- Pending implementation and verification.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -17,6 +17,7 @@ SCENE_LIFECYCLE_PLAN="$ROOT_DIR/docs/plans/2026-06-10-scene-action-lifecycle.md"
 CI_POLICY_PLAN="$ROOT_DIR/docs/plans/2026-06-12-ci-policy-hardening.md"
 SCHEME_TARGET_PLAN="$ROOT_DIR/docs/plans/2026-06-12-shared-scheme-target-integrity.md"
 COLLISION_PAIR_PLAN="$ROOT_DIR/docs/plans/2026-06-13-explicit-collision-pairing.md"
+PRESENTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-scene-presentation-idempotency.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 PROJECT_FILE="$ROOT_DIR/GameOfThrows.xcodeproj/project.pbxproj"
 SHARED_SCHEMES="$ROOT_DIR/GameOfThrows.xcodeproj/xcshareddata/xcschemes"
@@ -68,6 +69,7 @@ for path in \
 done
 
 require_file "docs/plans/2026-06-13-explicit-collision-pairing.md"
+require_file "docs/plans/2026-06-13-scene-presentation-idempotency.md"
 
 makefile="$ROOT_DIR/Makefile"
 if ! grep -Eq '^\.PHONY: .*build.*check.*lint.*test|^\.PHONY: .*build.*lint.*test.*check' "$makefile" ||
@@ -81,6 +83,26 @@ import sys
 from pathlib import Path
 
 source = Path(sys.argv[1]).read_text()
+presentation_helper = source[
+    source.index("func resetScenePresentation"):
+    source.index("override func didMoveToView")
+]
+presentation = source[
+    source.index("override func didMoveToView"):
+    source.index("override func willMoveFromView")
+]
+presentation_required = (
+    'self.removeActionForKey("spawnPipes")',
+    'self.removeActionForKey("flash")',
+    "self.removeAllChildren()",
+)
+if any(presentation_helper.count(item) != 1 for item in presentation_required):
+    raise SystemExit("Scene presentation reset must remove keyed actions and prior children.")
+if presentation.count("resetScenePresentation()") != 1:
+    raise SystemExit("didMoveToView must reset prior scene presentation state exactly once.")
+if presentation.index("resetScenePresentation()") > presentation.index("canRestart = false"):
+    raise SystemExit("Scene presentation reset must run before gameplay setup begins.")
+
 required = (
     "func isBirdCollisionContact(contact: SKPhysicsContact) -> Bool",
     "let bodyAIsObstacle = bodyMatchesCategory(contact.bodyA, category: worldCategory) ||",
@@ -469,11 +491,46 @@ if (
     )
 PY
 
+python3 - "$PRESENTATION_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "presentation reset mutation failed",
+    "child cleanup mutation failed",
+    "setup ordering mutation failed",
+    "hosted pull-request check",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Scene presentation idempotency plan must remain completed with actual verification recorded."
+    )
+PY
+
 if ! grep -Fq "only explicit bird-world or bird-pipe contacts end a run" "$ROOT_DIR/README.md" ||
   ! grep -Fq "Only explicit bird-world or bird-pipe contacts should trigger game-over" "$ROOT_DIR/SECURITY.md" ||
   ! grep -Fq "Only explicit bird-world or bird-pipe contacts stop gameplay" "$ROOT_DIR/VISION.md" ||
   ! grep -Fq "Required explicit bird-world or bird-pipe pairing" "$ROOT_DIR/CHANGES.md"; then
   printf '%s\n' "Project guidance must document explicit fatal collision pairing." >&2
+  exit 1
+fi
+
+if ! grep -Fq "Scene presentation clears prior keyed actions and child nodes before rebuilding gameplay" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "Scene presentation should clear prior keyed actions and child nodes before rebuilding gameplay" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "Scene presentation clears prior keyed actions and child nodes before rebuilding gameplay" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "Made repeated scene presentation clear prior keyed actions and child nodes" "$ROOT_DIR/CHANGES.md" ||
+  ! grep -Fq "Clear prior keyed actions and child nodes before rebuilding a presented scene" "$ROOT_DIR/AGENTS.md"; then
+  printf '%s\n' "Project guidance must document idempotent scene presentation." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Clear scene-owned pipe-spawn and flash actions before each SpriteKit presentation.
- Remove the prior child graph before rebuilding the bird, ground, pipes, and score label.
- Add method-scoped static and hostile-mutation contracts plus completed plan evidence.

## Baseline

- Stacked on PR #8 at exact base `ca5199cd891380343b8ea892a9d983aebec7a5a4`.
- Preserves first-presentation, scoring, collision, restart, and teardown behavior.
- Runtime simulator gameplay remains outside hosted coverage because the legacy Xcode toolchain is unavailable.

## Improvements

- make repeated scene presentation idempotent by clearing scene-owned actions
- discard the prior child graph before rebuilding presentation state
- retain existing first-presentation and gameplay behavior
- enforce reset, cleanup, and setup ordering with static and mutation contracts

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- shell syntax, plist parsing, shared-scheme XML parsing, and `git diff --check`
- intended-path artifact and secret scans
- mutations removing the presentation reset, child cleanup, or setup ordering each failed

## Risk

- Low and lifecycle-scoped. The archived scene contains no authored child graph, so initial presentation remains equivalent.
- Re-presenting the same scene now intentionally discards stale children before reconstruction.

## Post-Deploy Monitoring & Validation

- Confirm both canonical push and pull-request checks complete on the exact head.
- Confirm exact-head code scanning reports no open alerts.
- On a compatible legacy simulator, present the same scene instance twice and verify one bird, score label, ground graph, and pipe loop.

## Follow-Ups

- Add runtime re-presentation coverage only when a compatible simulator toolchain is available.
- Keep broader Swift modernization separate from this lifecycle fix.

[![Compound Engineering](https://img.shields.io/badge/Compound-Engineering-6f42c1)](https://github.com/EveryInc/compound-engineering-plugin)
