### PR TITLE
fix: cancel stale restart rotation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ maintenance baseline for the legacy Xcode project.
 - Keep repeating SpriteKit actions weakly captured and remove scene actions and
   contact callbacks when a scene leaves its view.
 - Clear prior keyed actions and child nodes before rebuilding a presented scene.
+- Cancel pending keyed collision actions before restoring restart state.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes that touch SpriteKit scene loading, assets, build scripts, project files, or UI test setup.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Cancelled the keyed death rotation before restart restores bird state,
+  preventing a prior collision completion from stopping the new run's bird.
 - Made repeated scene presentation clear prior keyed actions and child nodes
   before rebuilding the gameplay graph.
 - Required explicit bird-world or bird-pipe pairing before contact handling can

--- a/GameOfThrows/GameScene.swift
+++ b/GameOfThrows/GameScene.swift
@@ -215,6 +215,8 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
             return
         }
 
+        bird.removeActionForKey("deathRotation")
+
         // Move bird to original position and reset velocity
         bird.position = CGPointMake(self.frame.size.width / 2.5, CGRectGetMidY(self.frame))
         bird.physicsBody?.velocity = CGVectorMake( 0, 0 )
@@ -339,7 +341,9 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
         moving.speed = 0
 
         bird.physicsBody?.collisionBitMask = worldCategory
-        bird.runAction(  SKAction.rotateByAngle(CGFloat(M_PI) * CGFloat(bird.position.y) * 0.01, duration:1), completion:{bird.speed = 0 })
+        let deathRotation = SKAction.rotateByAngle(CGFloat(M_PI) * CGFloat(bird.position.y) * 0.01, duration:1)
+        let stopBird = SKAction.runBlock({ bird.speed = 0 })
+        bird.runAction(SKAction.sequence([deathRotation, stopBird]), withKey: "deathRotation")
 
 
         // Flash background if contact is detected

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   pending flash work when the scene leaves its SpriteKit view.
 - Scene presentation clears prior keyed actions and child nodes before rebuilding gameplay,
   preventing duplicate physics and rendering graphs when a scene is presented again.
+- Restart cancels the keyed death rotation before restoring bird state, so a
+  prior collision cannot stop animation in the new run.
 - Shared schemes may reference only targets present in `project.pbxproj`; the
   app scheme runs the existing UI launch test without the removed unit-test
   bundle.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,8 @@ Repeating SpriteKit actions should not retain scenes after presentation ends;
 teardown should remove pending actions and physics contact callbacks.
 Scene presentation should clear prior keyed actions and child nodes before rebuilding gameplay
 so stale physics bodies cannot remain active after re-presentation.
+Restart should cancel pending keyed collision actions before restoring bird state
+so stale completions cannot mutate a new gameplay round.
 
 ## Dependency and Supply Chain Security
 

--- a/VISION.md
+++ b/VISION.md
@@ -55,6 +55,8 @@ Current baseline:
   reading movement state.
 - Scene presentation clears prior keyed actions and child nodes before rebuilding gameplay,
   keeping repeated presentation from duplicating interactive scene state.
+- Restart cancels pending keyed collision work before restoring bird state so
+  an earlier run cannot mutate the new round.
 - The scene tears down repeating actions and its physics contact delegate when
   it leaves the SpriteKit view; the spawn closure does not retain the scene.
 - The local Makefile exposes lint, test, build, and check targets for a stable

--- a/docs/plans/2026-06-13-restart-death-rotation-cancellation.md
+++ b/docs/plans/2026-06-13-restart-death-rotation-cancellation.md
@@ -1,0 +1,60 @@
+---
+title: Restart Death Rotation Cancellation
+date: 2026-06-13
+status: planned
+execution: code
+---
+
+## Context
+
+A fatal contact starts a one-second bird rotation whose completion sets
+`bird.speed` to zero. The flash sequence enables restart after roughly 0.4
+seconds, so a player can restart while the old rotation is still active. The
+restart restores bird state, but the prior completion can then fire against the
+restarted bird and stop its animation.
+
+## Priority
+
+This is the highest-value remaining isolated restart boundary because stale
+collision work can mutate a new gameplay round after reset. The fix can make
+that ownership explicit without changing collision classification, timing,
+physics, scoring, or the restart gesture.
+
+## Prioritized Backlog
+
+1. Give the fatal bird rotation one stable action key.
+2. Cancel that action before restart mutates bird position, velocity, speed, or
+   rotation.
+3. Preserve the current one-second rotation and final stopped animation when a
+   restart does not occur.
+4. Add source-order and hostile-mutation contracts plus repository guidance.
+5. Keep runtime rapid-restart coverage and Swift modernization as separate work
+   requiring a compatible legacy simulator toolchain.
+
+## Implementation
+
+- Express the existing rotation and final `bird.speed = 0` transition as a
+  keyed action sequence.
+- Remove the keyed action at the start of the guarded restart path before any
+  bird state is restored.
+- Extend the static baseline to require the action key, cancellation, ordering,
+  documentation, and completed verification evidence.
+- Update README, SECURITY, VISION, CHANGES, and AGENTS guidance with the stale
+  collision-action boundary.
+
+## Verification Plan
+
+- Run shell syntax, all four Make gates, plist/project/workspace parsing,
+  `git diff --check`, and intended-file artifact and secret checks.
+- Remove the action key, remove restart cancellation, and move cancellation
+  after bird reset state; each hostile mutation must fail.
+- Take one bounded exact-head pull-request and code-scanning snapshot after
+  push; do not poll.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and verification.

--- a/docs/plans/2026-06-13-restart-death-rotation-cancellation.md
+++ b/docs/plans/2026-06-13-restart-death-rotation-cancellation.md
@@ -1,7 +1,7 @@
 ---
 title: Restart Death Rotation Cancellation
 date: 2026-06-13
-status: planned
+status: completed
 execution: code
 ---
 
@@ -53,8 +53,23 @@ physics, scoring, or the restart gesture.
 
 ## Work Completed
 
-Pending implementation.
+- Converted the existing fatal rotation and final bird stop into one keyed
+  `deathRotation` action sequence.
+- Cancelled the keyed sequence before restart restores bird position, velocity,
+  collision state, speed, rotation, score, or movement.
+- Added source-shape, ordering, documentation, and completed-plan contracts.
 
 ## Verification Completed
 
-Pending implementation and verification.
+- The action key mutation failed after replacing the keyed sequence with an
+  unkeyed run action.
+- The restart cancellation mutation failed after removing the keyed action
+  removal from `resetScene`.
+- The cancellation ordering mutation failed after moving action removal below
+  bird position restoration.
+- Shell syntax, all four Make gates, plist/project/workspace parsing,
+  `git diff --check`, and intended-file artifact and secret scans passed.
+- The hosted pull-request check is a post-push evidence step; its bounded
+  exact-head result is recorded after the implementation commit is pushed.
+- `xcodebuild`, SpriteKit runtime execution, and rapid restart interaction are
+  unavailable on this Linux host and are not claimed.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -18,6 +18,7 @@ CI_POLICY_PLAN="$ROOT_DIR/docs/plans/2026-06-12-ci-policy-hardening.md"
 SCHEME_TARGET_PLAN="$ROOT_DIR/docs/plans/2026-06-12-shared-scheme-target-integrity.md"
 COLLISION_PAIR_PLAN="$ROOT_DIR/docs/plans/2026-06-13-explicit-collision-pairing.md"
 PRESENTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-scene-presentation-idempotency.md"
+RESTART_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-restart-death-rotation-cancellation.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 PROJECT_FILE="$ROOT_DIR/GameOfThrows.xcodeproj/project.pbxproj"
 SHARED_SCHEMES="$ROOT_DIR/GameOfThrows.xcodeproj/xcshareddata/xcschemes"
@@ -70,6 +71,7 @@ done
 
 require_file "docs/plans/2026-06-13-explicit-collision-pairing.md"
 require_file "docs/plans/2026-06-13-scene-presentation-idempotency.md"
+require_file "docs/plans/2026-06-13-restart-death-rotation-cancellation.md"
 
 makefile="$ROOT_DIR/Makefile"
 if ! grep -Eq '^\.PHONY: .*build.*check.*lint.*test|^\.PHONY: .*build.*lint.*test.*check' "$makefile" ||
@@ -102,6 +104,27 @@ if presentation.count("resetScenePresentation()") != 1:
     raise SystemExit("didMoveToView must reset prior scene presentation state exactly once.")
 if presentation.index("resetScenePresentation()") > presentation.index("canRestart = false"):
     raise SystemExit("Scene presentation reset must run before gameplay setup begins.")
+
+restart = source[
+    source.index("func resetScene"):
+    source.index("override func touchesBegan")
+]
+collision = source[source.index("func didBeginContact"):]
+cancel_rotation = 'bird.removeActionForKey("deathRotation")'
+bird_reset = "bird.position = CGPointMake"
+if restart.count(cancel_rotation) != 1:
+    raise SystemExit("Restart must cancel the prior keyed death rotation exactly once.")
+if restart.index(cancel_rotation) > restart.index(bird_reset):
+    raise SystemExit("Restart must cancel the death rotation before restoring bird state.")
+death_rotation_required = (
+    "let deathRotation = SKAction.rotateByAngle",
+    "let stopBird = SKAction.runBlock({ bird.speed = 0 })",
+    'bird.runAction(SKAction.sequence([deathRotation, stopBird]), withKey: "deathRotation")',
+)
+if any(collision.count(item) != 1 for item in death_rotation_required):
+    raise SystemExit("Fatal collision rotation must remain one keyed stop sequence.")
+if "completion:{bird.speed = 0 }" in collision:
+    raise SystemExit("Fatal collision rotation must not retain an unkeyed late completion.")
 
 required = (
     "func isBirdCollisionContact(contact: SKPhysicsContact) -> Bool",
@@ -241,9 +264,9 @@ if ! grep -Fq "scoreLabelNode.setScale(1.0)" "$ROOT_DIR/GameOfThrows/GameScene.s
 fi
 
 if ! grep -Fq "let skyColor = skyColor" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
-  ! grep -Fq "completion:{bird.speed = 0" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
+  ! grep -Fq "let stopBird = SKAction.runBlock({ bird.speed = 0 })" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
   ! grep -Fq "self.backgroundColor = skyColor" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
-  grep -Fq "completion:{self.bird.speed = 0" "$ROOT_DIR/GameOfThrows/GameScene.swift"; then
+  grep -Fq "self.bird.speed = 0" "$ROOT_DIR/GameOfThrows/GameScene.swift"; then
   printf '%s\n' "GameScene contact handling must guard required scene resources and avoid delayed self.bird access." >&2
   exit 1
 fi
@@ -517,6 +540,32 @@ if (
     )
 PY
 
+python3 - "$RESTART_ROTATION_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "action key mutation failed",
+    "restart cancellation mutation failed",
+    "cancellation ordering mutation failed",
+    "hosted pull-request check",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Restart death rotation cancellation plan must remain completed with actual verification recorded."
+    )
+PY
+
 if ! grep -Fq "only explicit bird-world or bird-pipe contacts end a run" "$ROOT_DIR/README.md" ||
   ! grep -Fq "Only explicit bird-world or bird-pipe contacts should trigger game-over" "$ROOT_DIR/SECURITY.md" ||
   ! grep -Fq "Only explicit bird-world or bird-pipe contacts stop gameplay" "$ROOT_DIR/VISION.md" ||
@@ -531,6 +580,15 @@ if ! grep -Fq "Scene presentation clears prior keyed actions and child nodes bef
   ! grep -Fq "Made repeated scene presentation clear prior keyed actions and child nodes" "$ROOT_DIR/CHANGES.md" ||
   ! grep -Fq "Clear prior keyed actions and child nodes before rebuilding a presented scene" "$ROOT_DIR/AGENTS.md"; then
   printf '%s\n' "Project guidance must document idempotent scene presentation." >&2
+  exit 1
+fi
+
+if ! grep -Fq "Restart cancels the keyed death rotation before restoring bird state" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "Restart should cancel pending keyed collision actions before restoring bird state" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "Restart cancels pending keyed collision work before restoring bird state" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "Cancelled the keyed death rotation before restart restores bird state" "$ROOT_DIR/CHANGES.md" ||
+  ! grep -Fq "Cancel pending keyed collision actions before restoring restart state" "$ROOT_DIR/AGENTS.md"; then
+  printf '%s\n' "Project guidance must document restart cancellation of stale collision work." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

A rapid restart can no longer be modified by the previous run's fatal-collision completion. The existing death rotation is now a keyed sequence, and restart cancels it before restoring bird state.

## Baseline

This PR is stacked on `lfg/gameofthrows-scene-presentation-idempotency-20260613` (PR #9). Collision classification, one-second rotation timing, flash timing, physics, scoring, and the restart gesture remain unchanged.

## Improvements

- Preserve the fatal rotation and final stopped animation as one keyed SpriteKit action sequence.
- Cancel that sequence before restart mutates bird position, velocity, collision state, speed, rotation, score, or movement.
- Enforce action ownership, cancellation, ordering, documentation, and completed plan evidence in the deterministic baseline.

## Validation

- `make check`, `make lint`, `make test`, and `make build`
- Shell syntax, plist/project/workspace parsing, and `git diff --check`
- Three isolated hostile mutations rejected: missing action key, missing restart cancellation, and cancellation after bird restoration.
- Intended-path artifact, conflict-marker, and added-line secret scans passed.
- Structured correctness, testing, maintainability, project-standards, Swift/iOS, and reliability review found no actionable findings.
- Local checks truthfully reported `xcodebuild` unavailable.

## Risk

The behavior change is limited to restart during the existing one-second collision action. A collision that is not restarted still rotates for one second and stops bird animation as before; no simulator, device, or rapid-restart runtime interaction was available locally.

## Follow-Ups

- Keep PR #9 available and merge the stack in base order; do not merge this PR independently.
- Record exact-head hosted check and code-scanning evidence after the canonical events report.

## Post-Deploy Monitoring

- Rapidly restart as soon as the flash permits and confirm the bird continues animating and responding in the new round.
- Confirm an uninterrupted fatal collision still completes its rotation and stopped animation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
