### PR TITLE
Cancel death rotation during scene teardown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ maintenance baseline for the legacy Xcode project.
 - Keep repeating SpriteKit actions weakly captured and remove scene actions and
   contact callbacks when a scene leaves its view.
 - Clear prior keyed actions and child nodes before rebuilding a presented scene.
+- Cancel keyed bird collision actions before removing scene children or clearing the physics contact delegate.
 - Cancel pending keyed collision actions before restoring restart state.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes that touch SpriteKit scene loading, assets, build scripts, project files, or UI test setup.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-13
 
+- Cancelled the bird's keyed death rotation before scene presentation reset and view teardown cleanup.
 - Cancelled the keyed death rotation before restart restores bird state,
   preventing a prior collision completion from stopping the new run's bird.
 - Made repeated scene presentation clear prior keyed actions and child nodes

--- a/GameOfThrows/GameScene.swift
+++ b/GameOfThrows/GameScene.swift
@@ -23,7 +23,12 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
     let pipeCategory: UInt32 = 1 << 2
     let scoreCategory: UInt32 = 1 << 3
 
+    func cancelBirdDeathRotation() {
+        bird?.removeActionForKey("deathRotation")
+    }
+
     func resetScenePresentation() {
+        cancelBirdDeathRotation()
         self.removeActionForKey("spawnPipes")
         self.removeActionForKey("flash")
         self.removeAllChildren()
@@ -143,6 +148,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
     }
 
     override func willMoveFromView(view: SKView) {
+        cancelBirdDeathRotation()
         self.removeActionForKey("spawnPipes")
         self.removeActionForKey("flash")
         self.physicsWorld.contactDelegate = nil

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   pending flash work when the scene leaves its SpriteKit view.
 - Scene presentation clears prior keyed actions and child nodes before rebuilding gameplay,
   preventing duplicate physics and rendering graphs when a scene is presented again.
+- Presentation reset and view teardown cancel the bird's keyed death rotation before releasing child or delegate ownership.
 - Restart cancels the keyed death rotation before restoring bird state, so a
   prior collision cannot stop animation in the new run.
 - Shared schemes may reference only targets present in `project.pbxproj`; the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,7 @@ Repeating SpriteKit actions should not retain scenes after presentation ends;
 teardown should remove pending actions and physics contact callbacks.
 Scene presentation should clear prior keyed actions and child nodes before rebuilding gameplay
 so stale physics bodies cannot remain active after re-presentation.
+Presentation reset and view teardown should cancel the bird's keyed death rotation before child or contact-delegate cleanup.
 Restart should cancel pending keyed collision actions before restoring bird state
 so stale completions cannot mutate a new gameplay round.
 

--- a/VISION.md
+++ b/VISION.md
@@ -55,6 +55,7 @@ Current baseline:
   reading movement state.
 - Scene presentation clears prior keyed actions and child nodes before rebuilding gameplay,
   keeping repeated presentation from duplicating interactive scene state.
+- Presentation reset and view teardown cancel the bird's keyed death rotation before releasing child or delegate ownership.
 - Restart cancels pending keyed collision work before restoring bird state so
   an earlier run cannot mutate the new round.
 - The scene tears down repeating actions and its physics contact delegate when

--- a/docs/plans/2026-06-13-teardown-death-rotation-cancellation.md
+++ b/docs/plans/2026-06-13-teardown-death-rotation-cancellation.md
@@ -1,0 +1,38 @@
+---
+title: Teardown Death Rotation Cancellation
+type: reliability
+status: planned
+date: 2026-06-13
+---
+
+# Teardown Death Rotation Cancellation
+
+## Summary
+
+Cancel the bird's keyed death-rotation sequence before scene presentation reset
+or view teardown releases SpriteKit ownership.
+
+## Requirements
+
+- R1. Add one helper that removes the bird's `deathRotation` action when a bird
+  exists.
+- R2. Invoke the helper before `removeAllChildren()` during presentation reset.
+- R3. Invoke the helper before clearing the contact delegate during view
+  teardown.
+- R4. Keep restart cancellation, spawn/flash cleanup, scoring, collision, and
+  scene setup behavior unchanged.
+- R5. Add ordering, uniqueness, documentation, completion, and mutation
+  contracts.
+- R6. Do not claim simulator, device, or runtime SpriteKit verification.
+
+## Verification Plan
+
+- Run all four Make gates plus shell, plist/project/workspace, and diff checks.
+- Reject helper removal, presentation-order drift, teardown-order drift, stale
+  plan, and missing evidence mutations.
+- Take one bounded exact-head push/PR/code-scanning snapshot after push.
+
+## Non-Goals
+
+- Changing death animation timing, restart eligibility, physics, or scoring.
+- Replacing legacy SpriteKit APIs or project settings.

--- a/docs/plans/2026-06-13-teardown-death-rotation-cancellation.md
+++ b/docs/plans/2026-06-13-teardown-death-rotation-cancellation.md
@@ -1,7 +1,7 @@
 ---
 title: Teardown Death Rotation Cancellation
 type: reliability
-status: planned
+status: completed
 date: 2026-06-13
 ---
 
@@ -36,3 +36,12 @@ or view teardown releases SpriteKit ownership.
 
 - Changing death animation timing, restart eligibility, physics, or scoring.
 - Replacing legacy SpriteKit APIs or project settings.
+
+## Verification Completed
+
+- `make lint`, `make test`, `make build`, and `make check` completed; all four Make gates passed against the same working tree.
+- The five hostile mutations were rejected: helper removal, presentation cleanup
+  reordering, teardown cleanup reordering, stale plan status, and missing
+  verification evidence.
+- xcodebuild was unavailable on the Linux validation host.
+- No SpriteKit runtime, simulator, or device verification is claimed.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -19,6 +19,7 @@ SCHEME_TARGET_PLAN="$ROOT_DIR/docs/plans/2026-06-12-shared-scheme-target-integri
 COLLISION_PAIR_PLAN="$ROOT_DIR/docs/plans/2026-06-13-explicit-collision-pairing.md"
 PRESENTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-scene-presentation-idempotency.md"
 RESTART_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-restart-death-rotation-cancellation.md"
+TEARDOWN_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-teardown-death-rotation-cancellation.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 PROJECT_FILE="$ROOT_DIR/GameOfThrows.xcodeproj/project.pbxproj"
 SHARED_SCHEMES="$ROOT_DIR/GameOfThrows.xcodeproj/xcshareddata/xcschemes"
@@ -72,6 +73,7 @@ done
 require_file "docs/plans/2026-06-13-explicit-collision-pairing.md"
 require_file "docs/plans/2026-06-13-scene-presentation-idempotency.md"
 require_file "docs/plans/2026-06-13-restart-death-rotation-cancellation.md"
+require_file "docs/plans/2026-06-13-teardown-death-rotation-cancellation.md"
 
 makefile="$ROOT_DIR/Makefile"
 if ! grep -Eq '^\.PHONY: .*build.*check.*lint.*test|^\.PHONY: .*build.*lint.*test.*check' "$makefile" ||
@@ -85,6 +87,10 @@ import sys
 from pathlib import Path
 
 source = Path(sys.argv[1]).read_text()
+rotation_helper = source[
+    source.index("func cancelBirdDeathRotation"):
+    source.index("func resetScenePresentation")
+]
 presentation_helper = source[
     source.index("func resetScenePresentation"):
     source.index("override func didMoveToView")
@@ -93,6 +99,22 @@ presentation = source[
     source.index("override func didMoveToView"):
     source.index("override func willMoveFromView")
 ]
+teardown = source[
+    source.index("override func willMoveFromView"):
+    source.index("func spawnPipes")
+]
+cancel_rotation_helper = "cancelBirdDeathRotation()"
+optional_rotation_cancel = 'bird?.removeActionForKey("deathRotation")'
+if rotation_helper.count(optional_rotation_cancel) != 1:
+    raise SystemExit("Bird death rotation helper must cancel the keyed action exactly once when present.")
+if presentation_helper.count(cancel_rotation_helper) != 1:
+    raise SystemExit("Scene presentation reset must cancel bird death rotation exactly once.")
+if presentation_helper.index(cancel_rotation_helper) > presentation_helper.index("self.removeAllChildren()"):
+    raise SystemExit("Scene presentation reset must cancel bird death rotation before child cleanup.")
+if teardown.count(cancel_rotation_helper) != 1:
+    raise SystemExit("View teardown must cancel bird death rotation exactly once.")
+if teardown.index(cancel_rotation_helper) > teardown.index("self.physicsWorld.contactDelegate = nil"):
+    raise SystemExit("View teardown must cancel bird death rotation before contact delegate cleanup.")
 presentation_required = (
     'self.removeActionForKey("spawnPipes")',
     'self.removeActionForKey("flash")',
@@ -566,11 +588,46 @@ if (
     )
 PY
 
+python3 - "$TEARDOWN_ROTATION_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "five hostile mutations were rejected",
+    "all four Make gates passed",
+    "xcodebuild was unavailable",
+    "No SpriteKit runtime",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Teardown death rotation cancellation plan must remain completed with actual verification recorded."
+    )
+PY
+
 if ! grep -Fq "only explicit bird-world or bird-pipe contacts end a run" "$ROOT_DIR/README.md" ||
   ! grep -Fq "Only explicit bird-world or bird-pipe contacts should trigger game-over" "$ROOT_DIR/SECURITY.md" ||
   ! grep -Fq "Only explicit bird-world or bird-pipe contacts stop gameplay" "$ROOT_DIR/VISION.md" ||
   ! grep -Fq "Required explicit bird-world or bird-pipe pairing" "$ROOT_DIR/CHANGES.md"; then
   printf '%s\n' "Project guidance must document explicit fatal collision pairing." >&2
+  exit 1
+fi
+
+if ! grep -Fq "Presentation reset and view teardown cancel the bird's keyed death rotation before releasing child or delegate ownership" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "Presentation reset and view teardown should cancel the bird's keyed death rotation before child or contact-delegate cleanup" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "Presentation reset and view teardown cancel the bird's keyed death rotation before releasing child or delegate ownership" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "Cancelled the bird's keyed death rotation before scene presentation reset and view teardown cleanup" "$ROOT_DIR/CHANGES.md" ||
+  ! grep -Fq "Cancel keyed bird collision actions before removing scene children or clearing the physics contact delegate" "$ROOT_DIR/AGENTS.md"; then
+  printf '%s\n' "Project guidance must document cancellation before scene ownership cleanup." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- cancel the bird's keyed death rotation before presentation reset removes scene children
- cancel the same action before view teardown clears contact ownership
- enforce ordering, documentation, completion, and mutation contracts

## Baseline

Scene presentation reset and view teardown could remove scene children or clear contact ownership while the bird's keyed death-rotation action was still active.

## Improvements

Both teardown paths now cancel the keyed death rotation before mutating the scene or contact state, with explicit ordering and documentation contracts.

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- five hostile mutations rejected
- `git diff --check`
- exact head `fa10fc64ead591fe88edaae5b1b7967af9062bd8` has two successful hosted checks

## Risk

`xcodebuild` is unavailable on the Linux validation host. No SpriteKit runtime, simulator, or device verification is claimed.

## Follow-Ups

This change is stacked on `lfg/gameofthrows-restart-rotation-cancellation-20260613` (PR #10). Preserve that base relationship when reviewing or merging the pull request.
