### PR TITLE
test: make verification location independent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made static verification independent of the caller's working directory by
+  resolving the baseline checker from the loaded Makefile.
 - Cancelled the bird's keyed death rotation before scene presentation reset and view teardown cleanup.
 - Cancelled the keyed death rotation before restart restores bird state,
   preventing a prior collision completion from stopping the new run's bird.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: build check lint test
 
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 lint test build: check
 
 check:
-	./scripts/check-baseline.sh
+	@"$(ROOT)/scripts/check-baseline.sh"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   project, script, asset, and crash-hardening checks that do not require Xcode.
   The `lint`, `test`, and `build` targets currently delegate to the static
   baseline.
+- Use the absolute Makefile path to run the same gates from another working
+  directory. Verification resolves the checker relative to the loaded
+  Makefile rather than the caller's directory.
 - The static baseline also preserves the score sensor contract: each pipe score
   zone removes itself after the first contact so a single pass cannot count
   twice.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,0 +1,75 @@
+---
+title: Location-Independent GameOfThrows Verification
+type: reliability
+date: 2026-06-13
+status: planned
+execution: code
+---
+
+# Location-Independent GameOfThrows Verification
+
+## Summary
+
+Resolve the maintained static checker from the loaded Makefile so every
+documented gate works when Make is invoked outside the checkout.
+
+## Requirements
+
+- R1. Derive the repository root from `MAKEFILE_LIST`.
+- R2. Invoke `scripts/check-baseline.sh` through its repository-rooted path.
+- R3. Add a static contract that rejects caller-directory-relative invocation.
+- R4. Preserve all Swift, SpriteKit, Xcode project, plist, asset, workflow,
+  signing, and gameplay behavior.
+- R5. Record actual root and external-directory verification before completion.
+
+## Implementation Units
+
+### Rooted Make Entry Point
+
+Update `Makefile` to derive the checkout root from the loaded Makefile and use
+that root for the canonical checker recipe. Keep `lint`, `test`, and `build` as
+aliases of the same maintained baseline.
+
+### Verification Contract
+
+Extend `scripts/check-baseline.sh` with exact rooted-Makefile and completed-plan
+contracts. Synchronize the maintained command guidance without changing the
+legacy application or Xcode project.
+
+### Mutation Coverage
+
+Exercise isolated hostile mutations for root derivation, checker invocation,
+documentation, plan status, and recorded external verification.
+
+## Verification Plan
+
+- Run `make check`, `make lint`, `make test`, and `make build` at repository
+  root.
+- Run the full gate from `/tmp` through the absolute Makefile path.
+- Reject isolated hostile root-derivation, checker-path, documentation,
+  plan-status, and verification-evidence mutations.
+- Run shell syntax, plist/XML parsing, `git diff --check`, exact-path review,
+  secret/signing inspection, and generated-artifact inspection.
+
+## Non-Goals
+
+- Changing application runtime, dependencies, project settings, signing,
+  SpriteKit lifecycle, collision handling, scoring, restart, or teardown logic.
+- Claiming Xcode build, simulator, device, UI-test, or gameplay execution on
+  this Linux host.
+
+## Risks
+
+- Recursive verification would occur if the checker launched Make while
+  validating the external invocation; the contract will inspect the recipe and
+  the top-level validation will execute the external gate.
+- The legacy Apple runtime remains unverified locally because Xcode is not
+  available.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and validation.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -2,7 +2,7 @@
 title: Location-Independent GameOfThrows Verification
 type: reliability
 date: 2026-06-13
-status: planned
+status: completed
 execution: code
 ---
 
@@ -45,7 +45,7 @@ documentation, plan status, and recorded external verification.
 
 - Run `make check`, `make lint`, `make test`, and `make build` at repository
   root.
-- Run the full gate from `/tmp` through the absolute Makefile path.
+- Run the full gate from /tmp through the absolute Makefile path.
 - Reject isolated hostile root-derivation, checker-path, documentation,
   plan-status, and verification-evidence mutations.
 - Run shell syntax, plist/XML parsing, `git diff --check`, exact-path review,
@@ -68,8 +68,22 @@ documentation, plan status, and recorded external verification.
 
 ## Work Completed
 
-Pending implementation.
+- Derived the repository root from the loaded Makefile and invoked the static
+  checker through that absolute path.
+- Extended the baseline with rooted-Makefile, completed-plan, external-run, and
+  synchronized-guidance contracts.
+- Preserved all Swift, SpriteKit, Xcode project, plist, asset, workflow,
+  signing, and gameplay surfaces unchanged.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- `make check`, `make lint`, `make test`, and `make build` passed at repository
+  root.
+- The full gate passed from /tmp through the absolute Makefile path.
+- Five isolated hostile root-derivation, checker-path, documentation,
+  plan-status, and verification-evidence mutations were rejected.
+- Shell syntax, plist/XML parsing, `git diff --check`, exact-path review,
+  added-line secret/signing inspection, and generated-artifact inspection
+  passed.
+- Xcode build, simulator, device, UI-test, and gameplay behavior were
+  unavailable on this Linux host and are not claimed.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -20,6 +20,7 @@ COLLISION_PAIR_PLAN="$ROOT_DIR/docs/plans/2026-06-13-explicit-collision-pairing.
 PRESENTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-scene-presentation-idempotency.md"
 RESTART_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-restart-death-rotation-cancellation.md"
 TEARDOWN_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-teardown-death-rotation-cancellation.md"
+LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-independent-make.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 PROJECT_FILE="$ROOT_DIR/GameOfThrows.xcodeproj/project.pbxproj"
 SHARED_SCHEMES="$ROOT_DIR/GameOfThrows.xcodeproj/xcshareddata/xcschemes"
@@ -74,6 +75,21 @@ require_file "docs/plans/2026-06-13-explicit-collision-pairing.md"
 require_file "docs/plans/2026-06-13-scene-presentation-idempotency.md"
 require_file "docs/plans/2026-06-13-restart-death-rotation-cancellation.md"
 require_file "docs/plans/2026-06-13-teardown-death-rotation-cancellation.md"
+require_file "docs/plans/2026-06-13-location-independent-make.md"
+
+if ! grep -Fq 'ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' "$ROOT_DIR/Makefile" ||
+  ! grep -Fq '"$(ROOT)/scripts/check-baseline.sh"' "$ROOT_DIR/Makefile"; then
+  printf '%s\n' "Makefile verification must resolve the checker from the loaded Makefile." >&2
+  exit 1
+fi
+
+if ! grep -Fq "status: completed" "$LOCATION_INDEPENDENT_MAKE_PLAN" ||
+  ! grep -Fq "from /tmp" "$LOCATION_INDEPENDENT_MAKE_PLAN" ||
+  ! grep -Fq "absolute Makefile path" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "Made static verification independent" "$ROOT_DIR/CHANGES.md"; then
+  printf '%s\n' "Location-independent Make plan and guidance must record completed external verification." >&2
+  exit 1
+fi
 
 makefile="$ROOT_DIR/Makefile"
 if ! grep -Eq '^\.PHONY: .*build.*check.*lint.*test|^\.PHONY: .*build.*lint.*test.*check' "$makefile" ||


### PR DESCRIPTION
## Summary

The maintained GameOfThrows verification gates now run from any caller working directory. Invoking the repository's absolute Makefile path no longer tries to find `scripts/check-baseline.sh` under the caller's directory.

## Baseline

`make check` passed from the checkout, but `make -f /absolute/path/to/Makefile check` failed from `/tmp` with `./scripts/check-baseline.sh: Command not found`.

## Improvements

The Make entry point derives its root from the loaded Makefile and invokes the existing checker through that rooted path. The baseline now rejects caller-relative recipe regressions and requires completed external-run evidence while preserving the legacy Swift, SpriteKit, Xcode project, plist, asset, workflow, signing, and gameplay surfaces.

## Validation

- `make check`, `make lint`, `make test`, and `make build` passed at repository root.
- The same four gates passed from `/tmp` through the absolute Makefile path.
- Five isolated root-derivation, checker-path, documentation, plan-status, and verification-evidence mutations were rejected.
- Shell syntax, plist/XML parsing, `git diff --check`, intended-path review, added-line secret/signing inspection, and generated-artifact inspection passed.
- Plan-aware correctness, testing, maintainability, and project-standards review found no actionable findings.

## Risk

The change is limited to the static verification entry point and its documentation contracts. Xcode, simulator, device, UI-test, and gameplay execution remain unavailable on the Linux host and are not claimed.

## Follow-Ups

The stacked base PR #11 must remain available and merge first. Runtime validation still requires a compatible legacy Apple toolchain.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this repository has no deployed runtime surface. After merge, the owner should confirm the next push and pull-request `Check` jobs remain successful; any caller-directory-dependent checker failure is the rollback trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
