### PR TITLE
Preserve death rotation ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ maintenance baseline for the legacy Xcode project.
 - Clear prior keyed actions and child nodes before rebuilding a presented scene.
 - Cancel keyed bird collision actions before removing scene children or clearing the physics contact delegate.
 - Cancel pending keyed collision actions before restoring restart state.
+- Keep per-frame flight rotation behind the active-gameplay guard so the keyed
+  death-rotation action owns bird rotation after a fatal collision.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes that touch SpriteKit scene loading, assets, build scripts, project files, or UI test setup.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-14
+
+- Stopped per-frame flight orientation after gameplay ends so the keyed death
+  rotation remains the sole owner of bird rotation after a fatal collision.
+
 ## 2026-06-13
 
 - Made static verification independent of the caller's working directory by

--- a/GameOfThrows/GameScene.swift
+++ b/GameOfThrows/GameScene.swift
@@ -308,6 +308,10 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
     
     override func update(currentTime: CFTimeInterval) {
         /* Called before each frame is rendered */
+        if !isGameplayRunning() {
+            return
+        }
+
         guard let bird = bird, let physicsBody = bird.physicsBody else {
             return
         }

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Presentation reset and view teardown cancel the bird's keyed death rotation before releasing child or delegate ownership.
 - Restart cancels the keyed death rotation before restoring bird state, so a
   prior collision cannot stop animation in the new run.
+- Per-frame flight orientation stops with active gameplay so it cannot
+  overwrite the keyed death rotation after a fatal collision.
 - Shared schemes may reference only targets present in `project.pbxproj`; the
   app scheme runs the existing UI launch test without the removed unit-test
   bundle.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,8 @@ so stale physics bodies cannot remain active after re-presentation.
 Presentation reset and view teardown should cancel the bird's keyed death rotation before child or contact-delegate cleanup.
 Restart should cancel pending keyed collision actions before restoring bird state
 so stale completions cannot mutate a new gameplay round.
+Per-frame flight orientation should stop when gameplay stops so it cannot
+compete with the keyed death-rotation action after a fatal collision.
 
 ## Dependency and Supply Chain Security
 

--- a/VISION.md
+++ b/VISION.md
@@ -58,6 +58,8 @@ Current baseline:
 - Presentation reset and view teardown cancel the bird's keyed death rotation before releasing child or delegate ownership.
 - Restart cancels pending keyed collision work before restoring bird state so
   an earlier run cannot mutate the new round.
+- Per-frame flight orientation stops when gameplay stops, leaving fatal-contact
+  death rotation under one keyed action owner.
 - The scene tears down repeating actions and its physics contact delegate when
   it leaves the SpriteKit view; the spawn closure does not retain the scene.
 - The local Makefile exposes lint, test, build, and check targets for a stable

--- a/docs/plans/2026-06-14-update-rotation-ownership.md
+++ b/docs/plans/2026-06-14-update-rotation-ownership.md
@@ -1,0 +1,38 @@
+---
+title: Preserve Death Rotation Ownership
+type: reliability
+date: 2026-06-14
+status: in_progress
+execution: code
+---
+
+# Preserve Death Rotation Ownership
+
+## Summary
+
+Stop the per-frame flight-orientation update once gameplay has ended so the
+keyed death-rotation action remains the sole owner of bird rotation after a
+fatal collision.
+
+## Requirements
+
+- R1. Return from `update` before reading bird physics when gameplay is stopped.
+- R2. Keep active-gameplay flight orientation unchanged.
+- R3. Preserve collision, restart, teardown, and action-cancellation behavior.
+- R4. Add a mutation-sensitive static contract for guard placement and plan
+  completion.
+
+## Verification Plan
+
+- Run the focused static contract and all four Make gates from the repository.
+- Run the canonical gate through the absolute Makefile path from `/tmp`.
+- Reject isolated mutations that remove, invert, or move the gameplay guard,
+  remove the rotation assignment, weaken evidence, or remove the new contract.
+- Audit shell syntax, plist/XML parsing, exact diff, artifacts, signing and
+  credential patterns, project/dependency drift, and conflict markers.
+
+## Platform Limitation
+
+Xcode, SpriteKit, a simulator, and an iOS device are unavailable on this Linux
+host. Swift compilation and visible gameplay behavior require hosted or manual
+Apple-platform validation and will not be claimed from local static checks.

--- a/docs/plans/2026-06-14-update-rotation-ownership.md
+++ b/docs/plans/2026-06-14-update-rotation-ownership.md
@@ -2,7 +2,7 @@
 title: Preserve Death Rotation Ownership
 type: reliability
 date: 2026-06-14
-status: in_progress
+status: completed
 execution: code
 ---
 
@@ -36,3 +36,24 @@ fatal collision.
 Xcode, SpriteKit, a simulator, and an iOS device are unavailable on this Linux
 host. Swift compilation and visible gameplay behavior require hosted or manual
 Apple-platform validation and will not be claimed from local static checks.
+
+## Work Completed
+
+- Added an active-gameplay return at the start of `update`, before bird physics
+  access and flight-orientation assignment.
+- Added a dedicated structural checker and wired it into the canonical baseline.
+- Synchronized contributor, change, security, readme, and vision guidance.
+
+## Verification Completed
+
+- The focused structural checker passed.
+- six isolated hostile mutations were rejected for removed, inverted, and
+  misplaced guards; removed rotation assignment; incomplete plan evidence; and
+  orphaned checker integration.
+- `make check`, `make lint`, `make test`, and `make build` passed at repository
+  root.
+- The full gate passed through the absolute Makefile path from `/tmp`.
+- Shell syntax, plist/XML parsing, exact diff, artifacts, signing and credential
+  patterns, project/workflow drift, whitespace, and conflict markers passed.
+- Xcode, SpriteKit, simulator, device, and gameplay execution were unavailable
+  on this Linux host and are not claimed.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -21,6 +21,8 @@ PRESENTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-scene-presentation-idempotenc
 RESTART_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-restart-death-rotation-cancellation.md"
 TEARDOWN_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-teardown-death-rotation-cancellation.md"
 LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-independent-make.md"
+UPDATE_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-14-update-rotation-ownership.md"
+UPDATE_ROTATION_CHECK="$ROOT_DIR/scripts/check-update-rotation-ownership.py"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 PROJECT_FILE="$ROOT_DIR/GameOfThrows.xcodeproj/project.pbxproj"
 SHARED_SCHEMES="$ROOT_DIR/GameOfThrows.xcodeproj/xcshareddata/xcschemes"
@@ -54,6 +56,8 @@ for path in \
   "GameOfThrows/AppDelegate.swift" \
   "GameOfThrowsUITests/Info.plist" \
   "GameOfThrowsUITests/GameOfThrowsUITests.swift" \
+  "scripts/check-update-rotation-ownership.py" \
+  "docs/plans/2026-06-14-update-rotation-ownership.md" \
   "docs/plans/2026-06-09-score-label-restart-reset.md" \
   "docs/plans/2026-06-09-contact-resource-guard.md" \
   "docs/plans/2026-06-09-score-contact-bird-pairing.md" \
@@ -76,6 +80,11 @@ require_file "docs/plans/2026-06-13-scene-presentation-idempotency.md"
 require_file "docs/plans/2026-06-13-restart-death-rotation-cancellation.md"
 require_file "docs/plans/2026-06-13-teardown-death-rotation-cancellation.md"
 require_file "docs/plans/2026-06-13-location-independent-make.md"
+
+python3 "$UPDATE_ROTATION_CHECK" \
+  "$ROOT_DIR/GameOfThrows/GameScene.swift" \
+  "$UPDATE_ROTATION_PLAN" \
+  "$ROOT_DIR/scripts/check-baseline.sh"
 
 if ! grep -Fq 'ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' "$ROOT_DIR/Makefile" ||
   ! grep -Fq '"$(ROOT)/scripts/check-baseline.sh"' "$ROOT_DIR/Makefile"; then

--- a/scripts/check-update-rotation-ownership.py
+++ b/scripts/check-update-rotation-ownership.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+plan = Path(sys.argv[2]).read_text(encoding="utf-8")
+baseline = Path(sys.argv[3]).read_text(encoding="utf-8")
+
+start = source.find("override func update(currentTime: CFTimeInterval)")
+end = source.find("\n    func didBeginContact", start)
+if start == -1 or end == -1:
+    raise SystemExit("GameScene update boundary is missing.")
+
+update = source[start:end]
+gameplay_guard = """if !isGameplayRunning() {
+            return
+        }"""
+guard_index = update.find(gameplay_guard)
+physics_index = update.find("guard let bird = bird, let physicsBody = bird.physicsBody")
+velocity_index = update.find("let verticalVelocity = physicsBody.velocity.dy")
+rotation_index = update.find("bird.zRotation = self.clamp(")
+if -1 in (guard_index, physics_index, velocity_index, rotation_index):
+    raise SystemExit("GameScene update rotation ownership contract is incomplete.")
+if not guard_index < physics_index < velocity_index < rotation_index:
+    raise SystemExit("Gameplay must stop update before physics access and rotation assignment.")
+
+for evidence in (
+    "status: completed",
+    "six isolated hostile mutations were rejected",
+    "absolute Makefile path from `/tmp`",
+    "Xcode, SpriteKit, simulator, device, and gameplay execution were unavailable",
+):
+    if evidence not in plan:
+        raise SystemExit("Rotation ownership plan evidence missing: " + evidence)
+
+for integration in (
+    'UPDATE_ROTATION_CHECK="$ROOT_DIR/scripts/check-update-rotation-ownership.py"',
+    'python3 "$UPDATE_ROTATION_CHECK"',
+    '"$ROOT_DIR/GameOfThrows/GameScene.swift"',
+    '"$UPDATE_ROTATION_PLAN"',
+):
+    if integration not in baseline:
+        raise SystemExit("Rotation ownership checker integration missing: " + integration)
+
+print("GameScene update rotation ownership checks passed.")


### PR DESCRIPTION
## Summary

- Stop per-frame flight orientation as soon as active gameplay ends.
- Leave fatal-contact bird rotation under the existing keyed death action.
- Add a mutation-sensitive structural checker and synchronized maintenance guidance.

## Baseline

`update` continued assigning `bird.zRotation` after a fatal collision had stopped movement. That per-frame write competed with the death-rotation action, so the collision animation did not have exclusive ownership of rotation.

## Improvements

- Restrict the per-frame orientation update to active gameplay.
- Preserve the existing keyed death action as the sole owner of fatal-contact rotation.
- Add structural regression coverage and synchronized maintenance documentation for the ownership boundary.

## Validation

- Focused structural checker passed.
- Six isolated hostile mutations were rejected.
- `make check`, `make lint`, `make test`, and `make build` passed.
- The absolute Makefile `check` target passed from `/tmp`.
- Shell syntax, plist/XML, exact diff, artifact, project/workflow drift, conflict-marker, signing, and credential audits passed.
- Both exact-head hosted `check` jobs completed successfully at `55f584c139cc33f53eb12f25b229da60b9ed9e8c`.

## Risk

Xcode, SpriteKit, simulator, device, UI-test, and gameplay execution are unavailable on this Linux host and are not claimed. The structural checks cover source ownership, but Apple-runtime behavior still requires manual validation.

## Follow-Ups

Run the gameplay verification on a compatible Apple toolchain. This PR is stacked on #12; keep the predecessor available and merge it first. Do not merge or close either PR without explicit owner authorization.
