### PR TITLE
fix: stop gameplay during scene teardown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@ maintenance baseline for the legacy Xcode project.
   and documentation intentionally change with it.
 - Keep repeating SpriteKit actions weakly captured and remove scene actions and
   contact callbacks when a scene leaves its view.
+- Stop the optional moving gameplay graph before teardown removes keyed actions
+  or clears physics contact ownership.
 - Clear prior keyed actions and child nodes before rebuilding a presented scene.
 - Cancel keyed bird collision actions before removing scene children or clearing the physics contact delegate.
 - Cancel pending keyed collision actions before restoring restart state.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-16
+
+- Stopped the moving gameplay graph before scene teardown releases keyed
+  actions and physics contact ownership, so late callbacks fail the shared
+  active-gameplay guard.
+
 ## 2026-06-14
 
 - Stopped per-frame flight orientation after gameplay ends so the keyed death

--- a/GameOfThrows/GameScene.swift
+++ b/GameOfThrows/GameScene.swift
@@ -148,6 +148,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
     }
 
     override func willMoveFromView(view: SKView) {
+        moving?.speed = 0
         cancelBirdDeathRotation()
         self.removeActionForKey("spawnPipes")
         self.removeActionForKey("flash")

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   work and avoids delayed `self.bird` access after a crash contact.
 - The repeating spawn action uses a weak scene capture and is removed with
   pending flash work when the scene leaves its SpriteKit view.
+- View teardown stops the moving graph first, making the shared
+  active-gameplay guard reject late frame, touch, contact, or spawn work before
+  scene actions and contact ownership are released.
 - Scene presentation clears prior keyed actions and child nodes before rebuilding gameplay,
   preventing duplicate physics and rendering graphs when a scene is presented again.
 - Presentation reset and view teardown cancel the bird's keyed death rotation before releasing child or delegate ownership.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,8 @@ Only explicit bird-world or bird-pipe contacts should trigger game-over;
 unrelated sensor contacts should not mutate movement or restart state.
 Repeating SpriteKit actions should not retain scenes after presentation ends;
 teardown should remove pending actions and physics contact callbacks.
+Teardown should stop the moving graph before releasing action and contact
+ownership so late callbacks cannot pass the shared active-gameplay guard.
 Scene presentation should clear prior keyed actions and child nodes before rebuilding gameplay
 so stale physics bodies cannot remain active after re-presentation.
 Presentation reset and view teardown should cancel the bird's keyed death rotation before child or contact-delegate cleanup.

--- a/VISION.md
+++ b/VISION.md
@@ -62,6 +62,8 @@ Current baseline:
   death rotation under one keyed action owner.
 - The scene tears down repeating actions and its physics contact delegate when
   it leaves the SpriteKit view; the spawn closure does not retain the scene.
+- View teardown stops the moving graph before releasing action and contact
+  ownership, making the shared gameplay predicate reject late callbacks.
 - The local Makefile exposes lint, test, build, and check targets for a stable
   pre-push gate.
 - UI tests keep a launch smoke test for basic app startup coverage.
@@ -90,6 +92,7 @@ Next priorities:
 - Keep touch, contact, and spawn decisions routed through the active-gameplay
   guard while movement state remains an implicitly unwrapped scene node
 - Keep repeating action ownership weak and scene teardown explicit
+- Keep teardown movement shutdown ahead of action and contact ownership cleanup
 - Keep shared schemes free of dangling project target references
 - Modernize Swift/project settings in a dedicated pass
 

--- a/docs/plans/2026-06-16-teardown-gameplay-state.md
+++ b/docs/plans/2026-06-16-teardown-gameplay-state.md
@@ -1,0 +1,96 @@
+---
+title: Teardown Gameplay State
+type: reliability
+status: planned
+date: 2026-06-16
+execution: code
+---
+
+# Teardown Gameplay State
+
+## Context
+
+`willMoveFromView` removes the scene-owned spawn and flash actions, cancels the
+bird's keyed death rotation, and clears the physics contact delegate. It does
+not stop the `moving` node. The shared `isGameplayRunning()` predicate therefore
+continues to return true while the scene is leaving its view, allowing a late
+frame, touch, or action callback to pass the active-gameplay guard and mutate a
+detached scene.
+
+## Priority
+
+This is the highest-value remaining isolated lifecycle boundary because every
+guarded gameplay entry point relies on `moving.speed > 0` as the authority for
+whether the current round is active. Teardown should revoke that authority
+before cancelling callbacks and releasing contact ownership.
+
+## Requirements
+
+- R1. Stop the current moving gameplay graph during `willMoveFromView` when it
+  exists.
+- R2. Stop gameplay before cancelling keyed scene actions or clearing the
+  physics contact delegate.
+- R3. Preserve presentation rebuilding, restart behavior, collision handling,
+  scoring, pipe timing, and death-animation timing.
+- R4. Keep teardown safe when `moving` has not been initialized.
+- R5. Add source-order, documentation, completed-plan, and mutation-sensitive
+  baseline contracts.
+- R6. Record the Linux static-validation boundary without claiming SpriteKit,
+  simulator, or device runtime execution.
+
+## Implementation Units
+
+### 1. Revoke Gameplay State During Teardown
+
+Files: `GameOfThrows/GameScene.swift`
+
+- Set the optional `moving` node's speed to zero at the start of
+  `willMoveFromView`.
+- Keep death-rotation cancellation, spawn/flash removal, and contact-delegate
+  cleanup in their existing order after gameplay is stopped.
+
+### 2. Protect the Lifecycle Contract
+
+Files: `scripts/check-baseline.sh`, `README.md`, `SECURITY.md`, `VISION.md`,
+`CHANGES.md`, `AGENTS.md`
+
+- Require optional-safe movement shutdown and its ordering before teardown
+  action/delegate cleanup.
+- Document that teardown changes the shared active-gameplay predicate before
+  releasing callback ownership.
+
+### 3. Record Verification Evidence
+
+Files: `docs/plans/2026-06-16-teardown-gameplay-state.md`
+
+- Record actual focused, full-gate, external-directory, mutation, audit, and
+  hosted results after execution.
+
+## Verification
+
+- Run `sh -n scripts/check-baseline.sh` and `sh -n build.sh`.
+- Run `make check`, `make lint`, `make test`, and `make build` with bounded
+  commands, plus `make check` through the absolute Makefile path from an
+  external directory.
+- Reject isolated mutations that remove the movement stop, make it unsafe for
+  incomplete setup, move it after keyed-action or delegate cleanup, remove
+  guidance, or falsify completed-plan evidence.
+- Audit the exact diff, generated artifacts, credential-like additions, file
+  modes, conflict markers, and branch/upstream state.
+- Take one bounded exact-head pull-request, check, and security snapshot after
+  push; do not start an unbounded wait.
+
+## Risks And Boundaries
+
+- Linux cannot execute SpriteKit, Xcode, simulator, or device lifecycle timing;
+  the maintained local proof is source-order and project-structure validation.
+- Stopping `moving` during teardown intentionally freezes child movement and
+  makes the existing gameplay predicate false. A later presentation rebuilds a
+  fresh moving graph, so no resume behavior is changed.
+- This plan does not modernize Swift 2 syntax or change legacy project settings.
+
+## Assumptions
+
+- `willMoveFromView` is the repository's authoritative scene teardown hook.
+- The existing `isGameplayRunning()` predicate remains the shared gate for
+  touch, contact, pipe-spawn, and frame-update work.

--- a/docs/plans/2026-06-16-teardown-gameplay-state.md
+++ b/docs/plans/2026-06-16-teardown-gameplay-state.md
@@ -1,7 +1,7 @@
 ---
 title: Teardown Gameplay State
 type: reliability
-status: planned
+status: completed
 date: 2026-06-16
 execution: code
 ---
@@ -94,3 +94,30 @@ Files: `docs/plans/2026-06-16-teardown-gameplay-state.md`
 - `willMoveFromView` is the repository's authoritative scene teardown hook.
 - The existing `isGameplayRunning()` predicate remains the shared gate for
   touch, contact, pipe-spawn, and frame-update work.
+
+## Work Completed
+
+- Stopped the optional moving graph at the start of `willMoveFromView`, before
+  keyed action cancellation and contact-delegate cleanup.
+- Added an order-sensitive static contract for optional safety, the stopped
+  state, and teardown ownership ordering.
+- Updated project guidance and change history with the shared gameplay-predicate
+  lifecycle boundary.
+
+## Verification Completed
+
+- `sh -n scripts/check-baseline.sh` and `sh -n build.sh` passed.
+- All four Make gates passed: `make check`, `make lint`, `make test`, and
+  `make build`.
+- External-directory `make check` passed through the absolute Makefile path.
+- Eight isolated mutations were rejected: movement-stop removal, unsafe access,
+  wrong state, action-order drift, delegate-order drift, guidance removal,
+  stale plan status, and missing bounded-observation evidence.
+- Compound Engineering review reported no actionable findings or testing gaps.
+- `xcodebuild` was unavailable on the Linux host. No SpriteKit runtime,
+  simulator, device, physics-contact, rendering, or transition timing execution
+  is claimed.
+- PR #14 exact-head snapshot at `1bed3fc2b1be35cec053300cb34d8f0c919c2938`
+  showed the canonical macOS `check` in progress, an OPEN and MERGEABLE pull
+  request, and zero open CodeQL, Dependabot, or secret-scanning alerts. No
+  polling wait was started.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -23,6 +23,7 @@ TEARDOWN_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-teardown-death-rotation-
 LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-independent-make.md"
 UPDATE_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-14-update-rotation-ownership.md"
 UPDATE_ROTATION_CHECK="$ROOT_DIR/scripts/check-update-rotation-ownership.py"
+TEARDOWN_GAMEPLAY_PLAN="$ROOT_DIR/docs/plans/2026-06-16-teardown-gameplay-state.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 PROJECT_FILE="$ROOT_DIR/GameOfThrows.xcodeproj/project.pbxproj"
 SHARED_SCHEMES="$ROOT_DIR/GameOfThrows.xcodeproj/xcshareddata/xcschemes"
@@ -80,6 +81,7 @@ require_file "docs/plans/2026-06-13-scene-presentation-idempotency.md"
 require_file "docs/plans/2026-06-13-restart-death-rotation-cancellation.md"
 require_file "docs/plans/2026-06-13-teardown-death-rotation-cancellation.md"
 require_file "docs/plans/2026-06-13-location-independent-make.md"
+require_file "docs/plans/2026-06-16-teardown-gameplay-state.md"
 
 python3 "$UPDATE_ROTATION_CHECK" \
   "$ROOT_DIR/GameOfThrows/GameScene.swift" \
@@ -327,6 +329,34 @@ if ! grep -Fq "[weak self] in self?.spawnPipes()" "$ROOT_DIR/GameOfThrows/GameSc
   printf '%s\n' "GameScene must release repeating actions and contact callbacks when leaving its view." >&2
   exit 1
 fi
+
+python3 - "$ROOT_DIR/GameOfThrows/GameScene.swift" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text()
+teardown = source.split("override func willMoveFromView", 1)[-1].split(
+    "func spawnPipes", 1
+)[0]
+contracts = (
+    "moving?.speed = 0",
+    "cancelBirdDeathRotation()",
+    'removeActionForKey("spawnPipes")',
+    'removeActionForKey("flash")',
+    "physicsWorld.contactDelegate = nil",
+)
+if any(teardown.count(contract) != 1 for contract in contracts):
+    raise SystemExit(
+        "GameScene teardown must stop optional gameplay state once before releasing callback ownership."
+    )
+positions = [teardown.index(contract) for contract in contracts]
+if positions != sorted(positions):
+    raise SystemExit(
+        "GameScene teardown must stop gameplay before cancelling actions and clearing contact ownership."
+    )
+if "moving.speed = 0" in teardown:
+    raise SystemExit("GameScene teardown must remain safe before moving is initialized.")
+PY
 
 if ! grep -Fq "guard let bird = bird" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
   ! grep -Fq "let pipes = pipes" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
@@ -653,6 +683,15 @@ if ! grep -Fq "Presentation reset and view teardown cancel the bird's keyed deat
   ! grep -Fq "Cancelled the bird's keyed death rotation before scene presentation reset and view teardown cleanup" "$ROOT_DIR/CHANGES.md" ||
   ! grep -Fq "Cancel keyed bird collision actions before removing scene children or clearing the physics contact delegate" "$ROOT_DIR/AGENTS.md"; then
   printf '%s\n' "Project guidance must document cancellation before scene ownership cleanup." >&2
+  exit 1
+fi
+
+if ! grep -Fq "View teardown stops the moving graph first" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "Teardown should stop the moving graph before releasing action and contact" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "View teardown stops the moving graph before releasing action and contact" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "Stopped the moving gameplay graph before scene teardown releases keyed" "$ROOT_DIR/CHANGES.md" ||
+  ! grep -Fq "Stop the optional moving gameplay graph before teardown removes keyed actions" "$ROOT_DIR/AGENTS.md"; then
+  printf '%s\n' "Project guidance must document gameplay shutdown before teardown ownership cleanup." >&2
   exit 1
 fi
 

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -748,3 +748,35 @@ if ! grep -Fq "status: completed" "$CI_POLICY_PLAN" ||
   printf '%s\n' "CI policy hardening plan must record completed mutation verification." >&2
   exit 1
 fi
+
+python3 - "$TEARDOWN_GAMEPLAY_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+normalized_verification = " ".join(verification.split())
+required = (
+    "All four Make gates passed",
+    "External-directory `make check` passed",
+    "Eight isolated mutations were rejected",
+    "no actionable findings or testing gaps",
+    "`xcodebuild` was unavailable",
+    "No SpriteKit runtime",
+    "PR #14 exact-head snapshot",
+    "canonical macOS `check` in progress",
+    "No polling wait was started",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in normalized_verification for item in required)
+    or re.search(r"\b(?:todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Teardown gameplay state plan must record completed status, actual verification, and the runtime boundary."
+    )
+PY


### PR DESCRIPTION
## Summary

Scene teardown now revokes the shared active-gameplay state before releasing SpriteKit action and contact ownership. Late frame, touch, contact, or pipe-spawn callbacks can no longer treat a detached scene as an active round.

## Baseline

`willMoveFromView` already cancelled the keyed death rotation, removed spawn and flash actions, and cleared the physics contact delegate. The moving graph still retained a positive speed, so `isGameplayRunning()` remained true throughout teardown.

## Improvements

- Stop the optional moving graph first in `willMoveFromView`.
- Preserve bird death-animation ownership because the bird is a direct scene child rather than a child of the moving graph.
- Enforce optional safety and teardown ordering through the dependency-free baseline.
- Document the shared gameplay-predicate lifecycle boundary across project guidance.

## Validation

- `sh -n scripts/check-baseline.sh` and `sh -n build.sh` passed.
- `make check`, `make lint`, `make test`, and `make build` passed.
- The complete check passed from an external working directory through the absolute Makefile path.
- Eight isolated mutations were rejected: removal, unsafe access, wrong state, action-order drift, delegate-order drift, guidance removal, stale plan status, and missing bounded-observation evidence.
- Exact diff, artifact, credential-pattern, conflict-marker, file-mode, and upstream-alignment audits passed.
- Structured review found no actionable findings or testing gaps.

## Risk

The production change is one optional-safe SpriteKit state assignment. Linux cannot run Xcode, a simulator, device lifecycle timing, physics contacts, or rendering; the maintained local evidence is static ordering and project validation. No Swift modernization, physics, scoring, restart, collision, or timing behavior changed.

## Follow-Ups

Merge only after stacked PR #13 lands. Neither pull request should be merged or closed without explicit owner authorization.

## Post-Deploy Monitoring & Validation

No additional production monitoring is available for this legacy sample. Before merge, require the exact-head hosted macOS project check to pass; on a compatible legacy simulator, the owner should verify scene dismissal/re-presentation, collision animation, restart, and pipe spawning during a short manual gameplay session. A project-parse failure or gameplay continuing after scene teardown is the rollback trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
