### PR TITLE
Revoke restart during scene teardown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,8 @@ maintenance baseline for the legacy Xcode project.
   and documentation intentionally change with it.
 - Keep repeating SpriteKit actions weakly captured and remove scene actions and
   contact callbacks when a scene leaves its view.
-- Stop the optional moving gameplay graph before teardown removes keyed actions
-  or clears physics contact ownership.
+- Revoke restart eligibility and stop the optional moving gameplay graph before
+  teardown removes keyed actions or clears physics contact ownership.
 - Clear prior keyed actions and child nodes before rebuilding a presented scene.
 - Cancel keyed bird collision actions before removing scene children or clearing the physics contact delegate.
 - Cancel pending keyed collision actions before restoring restart state.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-16
 
+- Revoked restart eligibility before scene teardown stops movement and releases
+  callback ownership, preventing late touches from reactivating detached play.
 - Stopped the moving gameplay graph before scene teardown releases keyed
   actions and physics contact ownership, so late callbacks fail the shared
   active-gameplay guard.

--- a/GameOfThrows/GameScene.swift
+++ b/GameOfThrows/GameScene.swift
@@ -148,6 +148,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
     }
 
     override func willMoveFromView(view: SKView) {
+        canRestart = false
         moving?.speed = 0
         cancelBirdDeathRotation()
         self.removeActionForKey("spawnPipes")

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   work and avoids delayed `self.bird` access after a crash contact.
 - The repeating spawn action uses a weak scene capture and is removed with
   pending flash work when the scene leaves its SpriteKit view.
-- View teardown stops the moving graph first, making the shared
-  active-gameplay guard reject late frame, touch, contact, or spawn work before
-  scene actions and contact ownership are released.
+- View teardown revokes restart eligibility and stops the moving graph first,
+  making late touches and the shared active-gameplay guard reject detached
+  scene work before actions and contact ownership are released.
 - Scene presentation clears prior keyed actions and child nodes before rebuilding gameplay,
   preventing duplicate physics and rendering graphs when a scene is presented again.
 - Presentation reset and view teardown cancel the bird's keyed death rotation before releasing child or delegate ownership.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,8 +41,9 @@ Only explicit bird-world or bird-pipe contacts should trigger game-over;
 unrelated sensor contacts should not mutate movement or restart state.
 Repeating SpriteKit actions should not retain scenes after presentation ends;
 teardown should remove pending actions and physics contact callbacks.
-Teardown should stop the moving graph before releasing action and contact
-ownership so late callbacks cannot pass the shared active-gameplay guard.
+Teardown should revoke restart eligibility and stop the moving graph before
+releasing action and contact ownership so late touches or callbacks cannot
+reactivate or mutate a detached scene.
 Scene presentation should clear prior keyed actions and child nodes before rebuilding gameplay
 so stale physics bodies cannot remain active after re-presentation.
 Presentation reset and view teardown should cancel the bird's keyed death rotation before child or contact-delegate cleanup.

--- a/VISION.md
+++ b/VISION.md
@@ -62,8 +62,9 @@ Current baseline:
   death rotation under one keyed action owner.
 - The scene tears down repeating actions and its physics contact delegate when
   it leaves the SpriteKit view; the spawn closure does not retain the scene.
-- View teardown stops the moving graph before releasing action and contact
-  ownership, making the shared gameplay predicate reject late callbacks.
+- View teardown revokes restart eligibility and stops the moving graph before
+  releasing action and contact ownership, preventing late detached-scene work
+  from restarting or mutating gameplay.
 - The local Makefile exposes lint, test, build, and check targets for a stable
   pre-push gate.
 - UI tests keep a launch smoke test for basic app startup coverage.

--- a/docs/plans/2026-06-16-teardown-restart-revocation.md
+++ b/docs/plans/2026-06-16-teardown-restart-revocation.md
@@ -1,0 +1,64 @@
+---
+title: Teardown Restart Revocation
+type: reliability
+status: planned
+date: 2026-06-16
+execution: code
+---
+
+# Teardown Restart Revocation
+
+## Context
+
+`willMoveFromView` now stops the moving graph before releasing scene-owned
+actions and contact handling. It does not clear `canRestart`. After the death
+flash enables restart, a late touch during teardown can therefore enter
+`resetScene()` and set `moving.speed = 1`, reactivating gameplay on a detached
+scene.
+
+## Requirements
+
+- R1. Revoke restart eligibility at the start of `willMoveFromView`.
+- R2. Revoke restart eligibility before stopping movement or releasing keyed
+  actions and contact ownership.
+- R3. Preserve normal death-to-restart behavior while the scene remains
+  presented.
+- R4. Add source-order, documentation, completed-plan, and mutation-sensitive
+  baseline contracts.
+- R5. Record the Linux static-validation boundary without claiming SpriteKit,
+  simulator, or device runtime execution.
+
+## Non-Goals
+
+- Do not change collision classification, score handling, pipe timing,
+  presentation rebuilding, or the normal restart sequence.
+- Do not modernize the Swift 2 or iOS 9-era project.
+
+## Implementation
+
+1. Set `canRestart = false` before stopping the optional moving graph in
+   `willMoveFromView`.
+2. Extend the baseline checker to enforce latch revocation and ordering before
+   movement, action, and delegate cleanup.
+3. Update project guidance and change history with the teardown restart
+   boundary.
+4. Record actual focused, full-gate, external-directory, mutation, review, and
+   hosted verification evidence.
+
+## Verification
+
+- Run `sh -n scripts/check-baseline.sh` and `sh -n build.sh`.
+- Run `make check`, `make lint`, `make test`, and `make build` with explicit
+  timeouts, plus the absolute-Makefile check from an external directory.
+- Reject isolated mutations that remove latch revocation, set the wrong value,
+  move it after movement or ownership cleanup, remove guidance, or reopen plan
+  evidence.
+- Audit the exact diff, generated artifacts, credential-like additions, file
+  modes, conflict markers, and branch/upstream state.
+
+## Risks And Boundaries
+
+- Linux cannot execute SpriteKit, Xcode, simulator, or device lifecycle timing;
+  the maintained local proof is source-order and project-structure validation.
+- The normal in-view restart path remains controlled by the death flash and is
+  intentionally unchanged.

--- a/docs/plans/2026-06-16-teardown-restart-revocation.md
+++ b/docs/plans/2026-06-16-teardown-restart-revocation.md
@@ -1,7 +1,7 @@
 ---
 title: Teardown Restart Revocation
 type: reliability
-status: planned
+status: completed
 date: 2026-06-16
 execution: code
 ---
@@ -62,3 +62,30 @@ scene.
   the maintained local proof is source-order and project-structure validation.
 - The normal in-view restart path remains controlled by the death flash and is
   intentionally unchanged.
+
+## Work Completed
+
+- Revoked restart eligibility before stopping the moving gameplay graph during
+  view teardown.
+- Extended the source-order baseline to require restart revocation before
+  movement, action, and contact-delegate cleanup.
+- Updated project guidance and change history with the late-touch boundary.
+
+## Verification Completed
+
+- `sh -n scripts/check-baseline.sh` and `sh -n build.sh` passed.
+- All four Make gates passed: `make check`, `make lint`, `make test`, and
+  `make build`.
+- External-directory `make check` passed through the absolute Makefile path.
+- Six isolated mutations were rejected: missing revocation, the wrong restart
+  value, revocation after movement, revocation after delegate cleanup, missing
+  guidance, and reopened completed-plan evidence.
+- Compound Engineering review reported no actionable findings or testing gaps.
+- `xcodebuild` was unavailable on Linux. No SpriteKit runtime, simulator,
+  device, rendering, touch-timing, or scene-transition execution is claimed.
+- PR #15 exact-head checks at implementation head
+  `40419889110320e4dc7558b3c1a93fc36e63910e` completed successfully for push
+  run 27646582344 and pull-request run 27646590073. The PR was OPEN and
+  MERGEABLE, its six required body sections were present exactly once, and
+  code-scanning, Dependabot, and secret-scanning queries returned zero open
+  alerts.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -784,3 +784,36 @@ if (
         "Teardown gameplay state plan must record completed status, actual verification, and the runtime boundary."
     )
 PY
+
+python3 - "$TEARDOWN_RESTART_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+normalized_verification = " ".join(verification.split())
+required = (
+    "All four Make gates passed",
+    "External-directory `make check` passed",
+    "Six isolated mutations were rejected",
+    "no actionable findings or testing gaps",
+    "`xcodebuild` was unavailable",
+    "No SpriteKit runtime",
+    "PR #15 exact-head checks",
+    "push run 27646582344",
+    "pull-request run 27646590073",
+    "zero open alerts",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in normalized_verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Teardown restart revocation plan must record completed status, actual verification, and the runtime boundary."
+    )
+PY

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -24,6 +24,7 @@ LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-indepen
 UPDATE_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-14-update-rotation-ownership.md"
 UPDATE_ROTATION_CHECK="$ROOT_DIR/scripts/check-update-rotation-ownership.py"
 TEARDOWN_GAMEPLAY_PLAN="$ROOT_DIR/docs/plans/2026-06-16-teardown-gameplay-state.md"
+TEARDOWN_RESTART_PLAN="$ROOT_DIR/docs/plans/2026-06-16-teardown-restart-revocation.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 PROJECT_FILE="$ROOT_DIR/GameOfThrows.xcodeproj/project.pbxproj"
 SHARED_SCHEMES="$ROOT_DIR/GameOfThrows.xcodeproj/xcshareddata/xcschemes"
@@ -82,6 +83,7 @@ require_file "docs/plans/2026-06-13-restart-death-rotation-cancellation.md"
 require_file "docs/plans/2026-06-13-teardown-death-rotation-cancellation.md"
 require_file "docs/plans/2026-06-13-location-independent-make.md"
 require_file "docs/plans/2026-06-16-teardown-gameplay-state.md"
+require_file "docs/plans/2026-06-16-teardown-restart-revocation.md"
 
 python3 "$UPDATE_ROTATION_CHECK" \
   "$ROOT_DIR/GameOfThrows/GameScene.swift" \
@@ -339,6 +341,7 @@ teardown = source.split("override func willMoveFromView", 1)[-1].split(
     "func spawnPipes", 1
 )[0]
 contracts = (
+    "canRestart = false",
     "moving?.speed = 0",
     "cancelBirdDeathRotation()",
     'removeActionForKey("spawnPipes")',
@@ -352,7 +355,7 @@ if any(teardown.count(contract) != 1 for contract in contracts):
 positions = [teardown.index(contract) for contract in contracts]
 if positions != sorted(positions):
     raise SystemExit(
-        "GameScene teardown must stop gameplay before cancelling actions and clearing contact ownership."
+        "GameScene teardown must revoke restart and stop gameplay before releasing callback ownership."
     )
 if "moving.speed = 0" in teardown:
     raise SystemExit("GameScene teardown must remain safe before moving is initialized.")
@@ -686,12 +689,13 @@ if ! grep -Fq "Presentation reset and view teardown cancel the bird's keyed deat
   exit 1
 fi
 
-if ! grep -Fq "View teardown stops the moving graph first" "$ROOT_DIR/README.md" ||
-  ! grep -Fq "Teardown should stop the moving graph before releasing action and contact" "$ROOT_DIR/SECURITY.md" ||
-  ! grep -Fq "View teardown stops the moving graph before releasing action and contact" "$ROOT_DIR/VISION.md" ||
+if ! grep -Fq "View teardown revokes restart eligibility and stops the moving graph first" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "Teardown should revoke restart eligibility and stop the moving graph before" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "View teardown revokes restart eligibility and stops the moving graph before" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "Revoked restart eligibility before scene teardown stops movement" "$ROOT_DIR/CHANGES.md" ||
   ! grep -Fq "Stopped the moving gameplay graph before scene teardown releases keyed" "$ROOT_DIR/CHANGES.md" ||
-  ! grep -Fq "Stop the optional moving gameplay graph before teardown removes keyed actions" "$ROOT_DIR/AGENTS.md"; then
-  printf '%s\n' "Project guidance must document gameplay shutdown before teardown ownership cleanup." >&2
+  ! grep -Fq "Revoke restart eligibility and stop the optional moving gameplay graph before" "$ROOT_DIR/AGENTS.md"; then
+  printf '%s\n' "Project guidance must document restart revocation and gameplay shutdown before teardown ownership cleanup." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Prevent a late teardown touch from restarting the detached SpriteKit gameplay graph.

## Baseline

`willMoveFromView` stopped `moving` but left `canRestart` true. After the death flash enabled restart, a late touch could enter `resetScene()` and set `moving.speed = 1` during teardown.

## Improvements

- clear `canRestart` before stopping movement
- enforce ordering before action and contact-delegate cleanup
- document the restart-revocation boundary
- add mutation-sensitive static contracts

## Validation

- `sh -n scripts/check-baseline.sh`
- `sh -n build.sh`
- `make check`
- `make lint`
- `make test`
- `make build`
- external-directory absolute-Makefile check
- five isolated implementation and guidance mutations rejected

## Risk

Linux cannot execute Xcode, SpriteKit, simulator, or device lifecycle timing. The normal in-view death-to-restart path remains unchanged. This PR is stacked on open PR #14.

## Follow-Ups

Preserve merge ordering: PR #14 before this PR. No merge or close is performed by this change.

