### PR TITLE
build: restore hosted Swift app compilation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,10 +16,12 @@ jobs:
   check:
     runs-on: macos-15
     timeout-minutes: 10
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
     steps:
       - name: Check out repository
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
-      - name: Run static project baseline
+      - name: Run project baseline
         run: make check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Repository purpose
 
-`garethpaul/gameofthrows` is a preserved Swift 2 and SpriteKit iOS 9 sample
-inspired by Flappy Bird. It includes a small UI launch test and a static
-maintenance baseline for the legacy Xcode project.
+`garethpaul/gameofthrows` is a modernized Swift 5 and SpriteKit iOS 12 sample
+inspired by Flappy Bird. It includes a small UI launch test, a Linux static
+maintenance baseline, and a hosted Xcode 16.4 application build.
 
 ## Project structure
 
@@ -27,15 +27,16 @@ maintenance baseline for the legacy Xcode project.
 
 ## Coding conventions
 
-- Preserve the Swift 2 syntax and SpriteKit APIs unless modernization is the
-  explicit task and is verified with a compatible Xcode toolchain.
-- Preserve legacy Xcode project settings and signing assumptions unless the change is explicitly about modernization.
+- Preserve Swift 5 compatibility, the iOS 12 deployment floor, and current
+  SpriteKit API spellings unless a dedicated migration plan changes them.
+- Preserve signing assumptions and avoid broad Xcode project regeneration.
 
 ## Testing guidance
 
 - Test-related files detected: `GameOfThrows.xcodeproj/xcshareddata/xcschemes/GameOfThrowsUITests.xcscheme`, `GameOfThrowsUITests/GameOfThrowsUITests.swift`
-- Hosted macOS CI runs `make check` and parses the Xcode project; it does not
-  select a simulator, launch the app, or exercise gameplay.
+- Hosted macOS CI pins Xcode 16.4 and runs a code-signing-disabled application
+  build for a generic iOS Simulator destination; it does not boot a simulator,
+  launch the app, or exercise gameplay.
 - Start with the narrowest relevant test or Make target, then run `make check` before handing off if the change is not documentation-only.
 - Keep README verification notes in sync when commands, fixtures, or supported toolchains change.
 
@@ -49,7 +50,8 @@ maintenance baseline for the legacy Xcode project.
 ## Safety and gotchas
 
 - No required secret or credential file was identified in the repository scan. If you add integrations later, keep secrets out of git.
-- This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
+- Keep the checked-in Swift 5 language mode and iOS 12 deployment target aligned
+  with the pinned hosted Xcode 16.4 build.
 - Keep the checkout action pinned, read-only, and configured without persisted
   credentials; keep `check.yml` as the only hosted workflow unless the baseline
   and documentation intentionally change with it.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-17
+
+- Migrated the app and UI launch test from Swift 2-era syntax to Swift 5 while
+  preserving the existing SpriteKit gameplay and lifecycle contracts.
+- Raised both targets to iOS 12 and made the pinned Xcode 16.4 hosted gate
+  compile the app for a generic simulator with code signing disabled.
+
 ## 2026-06-16
 
 - Revoked restart eligibility before scene teardown stops movement and releases

--- a/GameOfThrows.xcodeproj/project.pbxproj
+++ b/GameOfThrows.xcodeproj/project.pbxproj
@@ -154,9 +154,9 @@
 		437451F2193D163700654986 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftMigration = 0730;
-				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastSwiftMigration = 1640;
+				LastSwiftUpdateCheck = 1640;
+				LastUpgradeCheck = 1640;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					437451F9193D163700654986 = {
@@ -284,7 +284,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				METAL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -321,7 +321,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				METAL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -337,11 +337,12 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				INFOPLIST_FILE = GameOfThrows/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.gpj.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -353,11 +354,12 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				INFOPLIST_FILE = GameOfThrows/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.gpj.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -369,12 +371,13 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = GameOfThrowsUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gpj.GameOfThrowsUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = GameOfThrows;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -387,12 +390,13 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = GameOfThrowsUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.gpj.GameOfThrowsUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = GameOfThrows;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/GameOfThrows.xcodeproj/xcshareddata/xcschemes/GameOfThrows.xcscheme
+++ b/GameOfThrows.xcodeproj/xcshareddata/xcschemes/GameOfThrows.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "1640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/GameOfThrows.xcodeproj/xcshareddata/xcschemes/GameOfThrowsUITests.xcscheme
+++ b/GameOfThrows.xcodeproj/xcshareddata/xcschemes/GameOfThrowsUITests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "1640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/GameOfThrows/AppDelegate.swift
+++ b/GameOfThrows/AppDelegate.swift
@@ -4,15 +4,17 @@
 
 import UIKit
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
                             
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
 }
-

--- a/GameOfThrows/GameScene.swift
+++ b/GameOfThrows/GameScene.swift
@@ -4,19 +4,19 @@
 
 import SpriteKit
 
-class GameScene: SKScene, SKPhysicsContactDelegate{
-    let verticalPipeGap = 150.0
-    
-    var bird:SKSpriteNode!
-    var skyColor:SKColor!
-    var pipeTextureUp:SKTexture!
-    var pipeTextureDown:SKTexture!
-    var movePipesAndRemove:SKAction!
-    var moving:SKNode!
-    var pipes:SKNode!
-    var canRestart = Bool()
-    var scoreLabelNode:SKLabelNode!
-    var score = NSInteger()
+class GameScene: SKScene, SKPhysicsContactDelegate {
+    let verticalPipeGap: CGFloat = 150.0
+
+    var bird: SKSpriteNode!
+    var skyColor: SKColor!
+    var pipeTextureUp: SKTexture!
+    var pipeTextureDown: SKTexture!
+    var movePipesAndRemove: SKAction!
+    var moving: SKNode!
+    var pipes: SKNode!
+    var canRestart = false
+    var scoreLabelNode: SKLabelNode!
+    var score = 0
     
     let birdCategory: UInt32 = 1 << 0
     let worldCategory: UInt32 = 1 << 1
@@ -24,136 +24,134 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
     let scoreCategory: UInt32 = 1 << 3
 
     func cancelBirdDeathRotation() {
-        bird?.removeActionForKey("deathRotation")
+        bird?.removeAction(forKey: "deathRotation")
     }
 
     func resetScenePresentation() {
         cancelBirdDeathRotation()
-        self.removeActionForKey("spawnPipes")
-        self.removeActionForKey("flash")
-        self.removeAllChildren()
+        removeAction(forKey: "spawnPipes")
+        removeAction(forKey: "flash")
+        removeAllChildren()
     }
-    
-    override func didMoveToView(view: SKView) {
+
+    override func didMove(to view: SKView) {
         resetScenePresentation()
-        
+
         canRestart = false
-        
+
         // setup physics
-        self.physicsWorld.gravity = CGVectorMake( 0.0, -5.0 )
-        self.physicsWorld.contactDelegate = self
-        
+        physicsWorld.gravity = CGVector(dx: 0.0, dy: -5.0)
+        physicsWorld.contactDelegate = self
+
         // setup background color
         skyColor = SKColor(red: 81.0/255.0, green: 192.0/255.0, blue: 201.0/255.0, alpha: 1.0)
-        self.backgroundColor = skyColor
-        
+        backgroundColor = skyColor
+
         moving = SKNode()
-        self.addChild(moving)
+        addChild(moving)
         pipes = SKNode()
         moving.addChild(pipes)
-        
+
         // ground
         let groundTexture = SKTexture(imageNamed: "land")
-        groundTexture.filteringMode = .Nearest // shorter form for SKTextureFilteringMode.Nearest
-        
-        let moveGroundSprite = SKAction.moveByX(-groundTexture.size().width * 2.0, y: 0, duration: NSTimeInterval(0.02 * groundTexture.size().width * 2.0))
-        let resetGroundSprite = SKAction.moveByX(groundTexture.size().width * 2.0, y: 0, duration: 0.0)
-        let moveGroundSpritesForever = SKAction.repeatActionForever(SKAction.sequence([moveGroundSprite,resetGroundSprite]))
-        
-        for i in 0 ..< Int(2.0 + self.frame.size.width / (groundTexture.size().width * 2.0)){
+        groundTexture.filteringMode = .nearest
+
+        let moveGroundSprite = SKAction.moveBy(x: -groundTexture.size().width * 2.0, y: 0, duration: TimeInterval(0.02 * groundTexture.size().width * 2.0))
+        let resetGroundSprite = SKAction.moveBy(x: groundTexture.size().width * 2.0, y: 0, duration: 0.0)
+        let moveGroundSpritesForever = SKAction.repeatForever(SKAction.sequence([moveGroundSprite, resetGroundSprite]))
+
+        for i in 0..<Int(2.0 + frame.size.width / (groundTexture.size().width * 2.0)) {
             let sprite = SKSpriteNode(texture: groundTexture)
             sprite.setScale(2.0)
-            sprite.position = CGPointMake(CGFloat(i) * sprite.size.width, sprite.size.height / 2.0)
-            sprite.runAction(moveGroundSpritesForever)
+            sprite.position = CGPoint(x: CGFloat(i) * sprite.size.width, y: sprite.size.height / 2.0)
+            sprite.run(moveGroundSpritesForever)
             moving.addChild(sprite)
         }
-        
+
         // skyline
         let skyTexture = SKTexture(imageNamed: "sky")
-        skyTexture.filteringMode = .Nearest
-        
-        let moveSkySprite = SKAction.moveByX(-skyTexture.size().width * 2.0, y: 0, duration: NSTimeInterval(0.1 * skyTexture.size().width * 2.0))
-        let resetSkySprite = SKAction.moveByX(skyTexture.size().width * 2.0, y: 0, duration: 0.0)
-        let moveSkySpritesForever = SKAction.repeatActionForever(SKAction.sequence([moveSkySprite,resetSkySprite]))
-        
-        for i in 0 ..< Int(2.0 + self.frame.size.width / (groundTexture.size().width * 2.0)){
+        skyTexture.filteringMode = .nearest
+
+        let moveSkySprite = SKAction.moveBy(x: -skyTexture.size().width * 2.0, y: 0, duration: TimeInterval(0.1 * skyTexture.size().width * 2.0))
+        let resetSkySprite = SKAction.moveBy(x: skyTexture.size().width * 2.0, y: 0, duration: 0.0)
+        let moveSkySpritesForever = SKAction.repeatForever(SKAction.sequence([moveSkySprite, resetSkySprite]))
+
+        for i in 0..<Int(2.0 + frame.size.width / (groundTexture.size().width * 2.0)) {
             let sprite = SKSpriteNode(texture: skyTexture)
             sprite.setScale(2.0)
             sprite.zPosition = -20
-            sprite.position = CGPointMake(CGFloat(i) * sprite.size.width, sprite.size.height / 2.0 + groundTexture.size().height * 2.0)
-            sprite.runAction(moveSkySpritesForever)
+            sprite.position = CGPoint(x: CGFloat(i) * sprite.size.width, y: sprite.size.height / 2.0 + groundTexture.size().height * 2.0)
+            sprite.run(moveSkySpritesForever)
             moving.addChild(sprite)
         }
-        
+
         // create the pipes textures
         pipeTextureUp = SKTexture(imageNamed: "PipeUp")
-        pipeTextureUp.filteringMode = .Nearest
+        pipeTextureUp.filteringMode = .nearest
         pipeTextureDown = SKTexture(imageNamed: "PipeDown")
-        pipeTextureDown.filteringMode = .Nearest
-        
+        pipeTextureDown.filteringMode = .nearest
+
         // create the pipes movement actions
-        let distanceToMove = CGFloat(self.frame.size.width + 2.0 * pipeTextureUp.size().width)
-        let movePipes = SKAction.moveByX(-distanceToMove, y:0.0, duration:NSTimeInterval(0.01 * distanceToMove))
+        let distanceToMove = frame.size.width + 2.0 * pipeTextureUp.size().width
+        let movePipes = SKAction.moveBy(x: -distanceToMove, y: 0.0, duration: TimeInterval(0.01 * distanceToMove))
         let removePipes = SKAction.removeFromParent()
         movePipesAndRemove = SKAction.sequence([movePipes, removePipes])
-        
+
         // spawn the pipes
-        let spawn = SKAction.runBlock({ [weak self] in self?.spawnPipes() })
-        let delay = SKAction.waitForDuration(NSTimeInterval(2.0))
+        let spawn = SKAction.run { [weak self] in self?.spawnPipes() }
+        let delay = SKAction.wait(forDuration: 2.0)
         let spawnThenDelay = SKAction.sequence([spawn, delay])
-        let spawnThenDelayForever = SKAction.repeatActionForever(spawnThenDelay)
-        self.runAction(spawnThenDelayForever, withKey: "spawnPipes")
-        
+        let spawnThenDelayForever = SKAction.repeatForever(spawnThenDelay)
+        run(spawnThenDelayForever, withKey: "spawnPipes")
+
         // setup our bird
         let birdTexture1 = SKTexture(imageNamed: "bird-01")
-        birdTexture1.filteringMode = .Nearest
+        birdTexture1.filteringMode = .nearest
         let birdTexture2 = SKTexture(imageNamed: "bird-02")
-        birdTexture2.filteringMode = .Nearest
-        
-        let anim = SKAction.animateWithTextures([birdTexture1, birdTexture2], timePerFrame: 0.2)
-        let flap = SKAction.repeatActionForever(anim)
-        
+        birdTexture2.filteringMode = .nearest
+
+        let anim = SKAction.animate(with: [birdTexture1, birdTexture2], timePerFrame: 0.2)
+        let flap = SKAction.repeatForever(anim)
+
         bird = SKSpriteNode(texture: birdTexture1)
         bird.setScale(2.0)
-        bird.position = CGPoint(x: self.frame.size.width * 0.35, y:self.frame.size.height * 0.6)
-        bird.runAction(flap)
-        
-        
+        bird.position = CGPoint(x: frame.size.width * 0.35, y: frame.size.height * 0.6)
+        bird.run(flap)
+
         bird.physicsBody = SKPhysicsBody(circleOfRadius: bird.size.height / 2.0)
-        bird.physicsBody?.dynamic = true
+        bird.physicsBody?.isDynamic = true
         bird.physicsBody?.allowsRotation = false
-        
+
         bird.physicsBody?.categoryBitMask = birdCategory
         bird.physicsBody?.collisionBitMask = worldCategory | pipeCategory
         bird.physicsBody?.contactTestBitMask = worldCategory | pipeCategory
-        
-        self.addChild(bird)
-        
+
+        addChild(bird)
+
         // create the ground
         let ground = SKNode()
-        ground.position = CGPointMake(0, groundTexture.size().height)
-        ground.physicsBody = SKPhysicsBody(rectangleOfSize: CGSizeMake(self.frame.size.width, groundTexture.size().height * 2.0))
-        ground.physicsBody?.dynamic = false
+        ground.position = CGPoint(x: 0, y: groundTexture.size().height)
+        ground.physicsBody = SKPhysicsBody(rectangleOf: CGSize(width: frame.size.width, height: groundTexture.size().height * 2.0))
+        ground.physicsBody?.isDynamic = false
         ground.physicsBody?.categoryBitMask = worldCategory
-        self.addChild(ground)
-        
+        addChild(ground)
+
         // Initialize label and create a label which holds the score
         score = 0
-        scoreLabelNode = SKLabelNode(fontNamed:"MarkerFelt-Wide")
-        scoreLabelNode.position = CGPointMake( CGRectGetMidX( self.frame ), 3 * self.frame.size.height / 4 )
+        scoreLabelNode = SKLabelNode(fontNamed: "MarkerFelt-Wide")
+        scoreLabelNode.position = CGPoint(x: frame.midX, y: 3 * frame.size.height / 4)
         scoreLabelNode.zPosition = 100
         scoreLabelNode.text = String(score)
-        self.addChild(scoreLabelNode)
-        
+        addChild(scoreLabelNode)
     }
 
-    override func willMoveFromView(view: SKView) {
+    override func willMove(from view: SKView) {
         canRestart = false
         moving?.speed = 0
         cancelBirdDeathRotation()
-        self.removeActionForKey("spawnPipes")
-        self.removeActionForKey("flash")
-        self.physicsWorld.contactDelegate = nil
+        removeAction(forKey: "spawnPipes")
+        removeAction(forKey: "flash")
+        physicsWorld.contactDelegate = nil
     }
     
     func spawnPipes() {
@@ -162,44 +160,41 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
         }
 
         let pipePair = SKNode()
-        pipePair.position = CGPointMake( self.frame.size.width + pipeTextureUp.size().width * 2, 0 )
+        pipePair.position = CGPoint(x: frame.size.width + pipeTextureUp.size().width * 2, y: 0)
         pipePair.zPosition = -10
-        
-        let height = max(UInt32(UInt(self.frame.size.height / 4)), 1)
+
+        let height = max(UInt32(frame.size.height / 4), 1)
         let y = arc4random_uniform(height) + height
-        
+
         let pipeDown = SKSpriteNode(texture: pipeTextureDown)
         pipeDown.setScale(2.0)
-        pipeDown.position = CGPointMake(0.0, CGFloat(Double(y)) + pipeDown.size.height + CGFloat(verticalPipeGap))
-        
-        
-        pipeDown.physicsBody = SKPhysicsBody(rectangleOfSize: pipeDown.size)
-        pipeDown.physicsBody?.dynamic = false
+        pipeDown.position = CGPoint(x: 0.0, y: CGFloat(y) + pipeDown.size.height + verticalPipeGap)
+
+        pipeDown.physicsBody = SKPhysicsBody(rectangleOf: pipeDown.size)
+        pipeDown.physicsBody?.isDynamic = false
         pipeDown.physicsBody?.categoryBitMask = pipeCategory
         pipeDown.physicsBody?.contactTestBitMask = birdCategory
         pipePair.addChild(pipeDown)
-        
+
         let pipeUp = SKSpriteNode(texture: pipeTextureUp)
         pipeUp.setScale(2.0)
-        pipeUp.position = CGPointMake(0.0, CGFloat(Double(y)))
-        
-        pipeUp.physicsBody = SKPhysicsBody(rectangleOfSize: pipeUp.size)
-        pipeUp.physicsBody?.dynamic = false
+        pipeUp.position = CGPoint(x: 0.0, y: CGFloat(y))
+
+        pipeUp.physicsBody = SKPhysicsBody(rectangleOf: pipeUp.size)
+        pipeUp.physicsBody?.isDynamic = false
         pipeUp.physicsBody?.categoryBitMask = pipeCategory
         pipeUp.physicsBody?.contactTestBitMask = birdCategory
         pipePair.addChild(pipeUp)
-        
+
         let contactNode = SKNode()
-        contactNode.position = CGPointMake( pipeDown.size.width + bird.size.width / 2, CGRectGetMidY( self.frame ) )
-        contactNode.physicsBody = SKPhysicsBody(rectangleOfSize: CGSizeMake( pipeUp.size.width, self.frame.size.height ))
-        contactNode.physicsBody?.dynamic = false
+        contactNode.position = CGPoint(x: pipeDown.size.width + bird.size.width / 2, y: frame.midY)
+        contactNode.physicsBody = SKPhysicsBody(rectangleOf: CGSize(width: pipeUp.size.width, height: frame.size.height))
+        contactNode.physicsBody?.isDynamic = false
         contactNode.physicsBody?.categoryBitMask = scoreCategory
         contactNode.physicsBody?.contactTestBitMask = birdCategory
         pipePair.addChild(contactNode)
-        
-        pipePair.runAction(movePipesAndRemove)
+        pipePair.run(movePipesAndRemove)
         pipes.addChild(pipePair)
-        
     }
 
     func shouldSpawnPipes() -> Bool {
@@ -215,7 +210,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
         return moving != nil && moving.speed > 0
     }
     
-    func resetScene (){
+    func resetScene() {
         guard let bird = bird,
             let pipes = pipes,
             let moving = moving,
@@ -223,11 +218,11 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
             return
         }
 
-        bird.removeActionForKey("deathRotation")
+        bird.removeAction(forKey: "deathRotation")
 
         // Move bird to original position and reset velocity
-        bird.position = CGPointMake(self.frame.size.width / 2.5, CGRectGetMidY(self.frame))
-        bird.physicsBody?.velocity = CGVectorMake( 0, 0 )
+        bird.position = CGPoint(x: frame.size.width / 2.5, y: frame.midY)
+        bird.physicsBody?.velocity = CGVector(dx: 0, dy: 0)
         bird.physicsBody?.collisionBitMask = worldCategory | pipeCategory
         bird.speed = 1.0
         bird.zRotation = 0.0
@@ -247,11 +242,11 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
         moving.speed = 1
     }
     
-    override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {        /* Called when a touch begins */
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         if isGameplayRunning() {
             applyBirdImpulse()
-        }else if canRestart {
-            self.resetScene()
+        } else if canRestart {
+            resetScene()
         }
     }
 
@@ -260,26 +255,26 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
             return
         }
 
-        physicsBody.velocity = CGVectorMake(0, 0)
-        physicsBody.applyImpulse(CGVectorMake(0, 30))
+        physicsBody.velocity = CGVector(dx: 0, dy: 0)
+        physicsBody.applyImpulse(CGVector(dx: 0, dy: 30))
     }
-    
+
     // TODO: Move to utilities somewhere. There's no reason this should be a member function
-    func clamp(min: CGFloat, max: CGFloat, value: CGFloat) -> CGFloat {
-        if( value > max ) {
-            return max
-        } else if( value < min ) {
-            return min
+    func clamp(minimum: CGFloat, maximum: CGFloat, value: CGFloat) -> CGFloat {
+        if value > maximum {
+            return maximum
+        } else if value < minimum {
+            return minimum
         } else {
             return value
         }
     }
 
-    func bodyMatchesCategory(body: SKPhysicsBody, category: UInt32) -> Bool {
-        return ( body.categoryBitMask & category ) == category
+    func bodyMatchesCategory(_ body: SKPhysicsBody, category: UInt32) -> Bool {
+        return (body.categoryBitMask & category) == category
     }
 
-    func scoreContactNode(contact: SKPhysicsContact) -> SKNode? {
+    func scoreContactNode(_ contact: SKPhysicsContact) -> SKNode? {
         let bodyAIsScore = bodyMatchesCategory(contact.bodyA, category: scoreCategory)
         let bodyBIsScore = bodyMatchesCategory(contact.bodyB, category: scoreCategory)
         let bodyAIsBird = bodyMatchesCategory(contact.bodyA, category: birdCategory)
@@ -296,7 +291,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
         return nil
     }
 
-    func isBirdCollisionContact(contact: SKPhysicsContact) -> Bool {
+    func isBirdCollisionContact(_ contact: SKPhysicsContact) -> Bool {
         let bodyAIsBird = bodyMatchesCategory(contact.bodyA, category: birdCategory)
         let bodyBIsBird = bodyMatchesCategory(contact.bodyB, category: birdCategory)
         let bodyAIsObstacle = bodyMatchesCategory(contact.bodyA, category: worldCategory) ||
@@ -306,9 +301,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
 
         return (bodyAIsBird && bodyBIsObstacle) || (bodyBIsBird && bodyAIsObstacle)
     }
-    
-    
-    override func update(currentTime: CFTimeInterval) {
+    override func update(_ currentTime: TimeInterval) {
         /* Called before each frame is rendered */
         if !isGameplayRunning() {
             return
@@ -319,10 +312,14 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
         }
 
         let verticalVelocity = physicsBody.velocity.dy
-        bird.zRotation = self.clamp( -1, max: 0.5, value: verticalVelocity * ( verticalVelocity < 0 ? 0.003 : 0.001 ) )
+        bird.zRotation = clamp(
+            minimum: -1,
+            maximum: 0.5,
+            value: verticalVelocity * (verticalVelocity < 0 ? 0.003 : 0.001)
+        )
     }
-    
-    func didBeginContact(contact: SKPhysicsContact) {
+
+    func didBegin(_ contact: SKPhysicsContact) {
         if !isGameplayRunning() {
             return
         }
@@ -342,7 +339,10 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
             scoreLabelNode.text = String(score)
 
             // Add a little visual feedback for the score increment
-            scoreLabelNode.runAction(SKAction.sequence([SKAction.scaleTo(1.5, duration:NSTimeInterval(0.1)), SKAction.scaleTo(1.0, duration:NSTimeInterval(0.1))]))
+            scoreLabelNode.run(SKAction.sequence([
+                SKAction.scale(to: 1.5, duration: 0.1),
+                SKAction.scale(to: 1.0, duration: 0.1)
+            ]))
             return
         }
 
@@ -353,19 +353,27 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
         moving.speed = 0
 
         bird.physicsBody?.collisionBitMask = worldCategory
-        let deathRotation = SKAction.rotateByAngle(CGFloat(M_PI) * CGFloat(bird.position.y) * 0.01, duration:1)
-        let stopBird = SKAction.runBlock({ bird.speed = 0 })
-        bird.runAction(SKAction.sequence([deathRotation, stopBird]), withKey: "deathRotation")
+        let deathRotation = SKAction.rotate(byAngle: .pi * bird.position.y * 0.01, duration: 1)
+        let stopBird = SKAction.run { bird.speed = 0 }
+        bird.run(SKAction.sequence([deathRotation, stopBird]), withKey: "deathRotation")
 
 
         // Flash background if contact is detected
-        self.removeActionForKey("flash")
-        self.runAction(SKAction.sequence([SKAction.repeatAction(SKAction.sequence([SKAction.runBlock({
-            self.backgroundColor = SKColor(red: 1, green: 0, blue: 0, alpha: 1.0)
-            }),SKAction.waitForDuration(NSTimeInterval(0.05)), SKAction.runBlock({
-                self.backgroundColor = skyColor
-                }), SKAction.waitForDuration(NSTimeInterval(0.05))]), count:4), SKAction.runBlock({
-                    self.canRestart = true
-                    })]), withKey: "flash")
+        removeAction(forKey: "flash")
+        run(SKAction.sequence([
+            SKAction.repeat(SKAction.sequence([
+                SKAction.run {
+                    self.backgroundColor = SKColor(red: 1, green: 0, blue: 0, alpha: 1.0)
+                },
+                SKAction.wait(forDuration: 0.05),
+                SKAction.run {
+                    self.backgroundColor = skyColor
+                },
+                SKAction.wait(forDuration: 0.05)
+            ]), count: 4),
+            SKAction.run {
+                self.canRestart = true
+            }
+        ]), withKey: "flash")
     }
 }

--- a/GameOfThrows/GameViewController.swift
+++ b/GameOfThrows/GameViewController.swift
@@ -5,48 +5,26 @@
 import UIKit
 import SpriteKit
 
-extension SKNode {
-    class func unarchiveFromFile(file : NSString) -> SKNode? {
-        guard let path = NSBundle.mainBundle().pathForResource(file as String, ofType: "sks"),
-            let sceneData = try? NSData(contentsOfFile: path, options: .DataReadingMappedIfSafe) else {
-            return nil
-        }
-
-        let archiver = NSKeyedUnarchiver(forReadingWithData: sceneData)
-        
-        archiver.setClass(self.classForKeyedUnarchiver(), forClassName: "SKScene")
-        guard let scene = archiver.decodeObjectForKey(NSKeyedArchiveRootObjectKey) as? GameScene else {
-            archiver.finishDecoding()
-            return nil
-        }
-
-        archiver.finishDecoding()
-        return scene
-    }
-}
-
 class GameViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if let scene = GameScene.unarchiveFromFile("GameScene") as? GameScene {
-            // Configure the view.
-            guard let skView = self.view as? SKView else {
-                return
-            }
-
-            skView.showsFPS = false
-            skView.showsNodeCount = false
-            
-            /* Sprite Kit applies additional optimizations to improve rendering performance */
-            skView.ignoresSiblingOrder = true
-            
-            /* Set the scale mode to scale to fit the window */
-            scene.scaleMode = .AspectFill
-            
-            skView.presentScene(scene)
+        guard let skView = view as? SKView,
+            let scene = GameScene(fileNamed: "GameScene") else {
+            return
         }
+
+        skView.showsFPS = false
+        skView.showsNodeCount = false
+
+        /* Sprite Kit applies additional optimizations to improve rendering performance */
+        skView.ignoresSiblingOrder = true
+
+        /* Set the scale mode to scale to fit the window */
+        scene.scaleMode = .aspectFill
+
+        skView.presentScene(scene)
     }
 
     override func shouldAutorotate() -> Bool {
@@ -54,10 +32,10 @@ class GameViewController: UIViewController {
     }
 
     override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
-        if UIDevice.currentDevice().userInterfaceIdiom == .Phone {
-            return UIInterfaceOrientationMask.AllButUpsideDown
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            return .allButUpsideDown
         } else {
-            return UIInterfaceOrientationMask.All
+            return .all
         }
     }
 

--- a/GameOfThrows/GameViewController.swift
+++ b/GameOfThrows/GameViewController.swift
@@ -27,11 +27,11 @@ class GameViewController: UIViewController {
         skView.presentScene(scene)
     }
 
-    override func shouldAutorotate() -> Bool {
+    override var shouldAutorotate: Bool {
         return true
     }
 
-    override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         if UIDevice.current.userInterfaceIdiom == .phone {
             return .allButUpsideDown
         } else {

--- a/GameOfThrowsUITests/GameOfThrowsUITests.swift
+++ b/GameOfThrowsUITests/GameOfThrowsUITests.swift
@@ -9,27 +9,20 @@
 import XCTest
 
 class GameOfThrowsUITests: XCTestCase {
-        
+
+    private var app: XCUIApplication!
+
     override func setUp() {
         super.setUp()
-        
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-        
+
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-        XCUIApplication().launch()
 
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        app = XCUIApplication()
+        app.launch()
     }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
+
     func testApplicationLaunches() {
-        XCTAssertTrue(XCUIApplication().exists)
+        XCTAssertTrue(app.exists)
     }
-    
 }

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 
 ## Testing and Verification
 
-- Run `make lint`, `make test`, `make build`, and `make check` for static
-  project, script, asset, and crash-hardening checks that do not require Xcode.
-  The `lint`, `test`, and `build` targets currently delegate to the static
-  baseline.
+- Run `make lint`, `make test`, `make build`, and `make check` for project,
+  script, asset, crash-hardening, and toolchain checks. On Linux the Xcode build
+  is truthfully skipped; on macOS the same baseline compiles the app with Swift
+  5 for a generic iOS Simulator destination with code signing disabled.
 - Use the absolute Makefile path to run the same gates from another working
   directory. Verification resolves the checker relative to the loaded
   Makefile rather than the caller's directory.
@@ -97,10 +97,12 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Run `./build.sh` on macOS with Xcode installed. Set `IOS_SIMULATOR_NAME` to
   override only the simulator name, or `IOS_DESTINATION` to provide a full
   xcodebuild destination string.
-- GitHub Actions runs `make check` on macOS with read-only permissions, an
-  immutable checkout action, and `persist-credentials: false`. It parses the
-  Xcode project without selecting an obsolete simulator. Run `build.sh`
-  explicitly for UI testing.
+- GitHub Actions pins Xcode 16.4 and runs `make check` on macOS with read-only
+  permissions, an immutable checkout action, and `persist-credentials: false`.
+  The gate compiles the Swift 5 app for a generic iOS Simulator destination;
+  run `build.sh` explicitly to boot a named simulator and execute UI tests.
+- The maintained Xcode project uses Swift 5 language mode and an iOS 12
+  deployment floor for both the app and UI-test targets.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,12 +54,16 @@ compete with the keyed death-rotation action after a fatal collision.
 
 ## Dependency and Supply Chain Security
 
-GitHub Actions runs the static resource and crash guardrails plus an Xcode
-project parse with read-only repository permissions before changes land.
+GitHub Actions runs the static resource and crash guardrails plus a
+code-signing-disabled Swift 5 application build with pinned Xcode 16.4 before
+changes land. The build targets a generic iOS Simulator and does not launch the
+app or exercise gameplay.
 The workflow uses an immutable checkout action without persisted credentials,
 and the local baseline rejects extra workflows or canonical job-shape drift.
 Shared Xcode schemes must reference only targets defined by the checked-in
 project so stale test entries cannot bypass the intended launch-test contract.
+The project must retain Swift 5 language mode and an iOS 12 deployment floor
+for both application and UI-test targets.
 
 Dependency updates should come from trusted package managers and should keep lockfiles in sync when lockfiles exist. Do not commit credentials, private keys, tokens, generated secrets, or machine-local configuration. If a vulnerability depends on a compromised package, typosquatting risk, insecure transitive dependency, or unsafe build step, include the package name, affected version, and the path through which it is used.
 

--- a/VISION.md
+++ b/VISION.md
@@ -95,7 +95,8 @@ Next priorities:
 - Keep repeating action ownership weak and scene teardown explicit
 - Keep teardown movement shutdown ahead of action and contact ownership cleanup
 - Keep shared schemes free of dangling project target references
-- Modernize Swift/project settings in a dedicated pass
+- Keep the completed Swift 5, iOS 12, and hosted Xcode 16.4 build boundary
+  explicit and mutation-tested
 
 Contribution rules:
 
@@ -116,7 +117,7 @@ should be opt-in, documented, and avoid collecting unnecessary user data.
 ## What We Will Not Merge (For Now)
 
 - Asset replacements without purpose or provenance
-- Broad Swift migrations mixed with gameplay changes
+- Broad Swift or project migrations mixed with gameplay changes
 - Analytics or tracking features
 - Build changes that make the sample harder to open in Xcode
 

--- a/docs/plans/2026-06-17-swift-xcode-build-modernization.md
+++ b/docs/plans/2026-06-17-swift-xcode-build-modernization.md
@@ -2,7 +2,7 @@
 title: Modernize GameOfThrows for hosted Xcode builds
 type: modernization
 date: 2026-06-17
-status: planned
+status: completed
 execution: code
 ---
 
@@ -125,6 +125,41 @@ Linux limitation, and record only verification that actually ran.
   markers, executable modes, and credential-shaped additions.
 - Require the canonical push and pull-request macOS jobs to compile the exact
   delivery head successfully before recording terminal evidence.
+
+## Work Completed
+
+- Migrated the application and launch smoke-test sources from Swift 2 syntax
+  to Swift 5-compatible UIKit and SpriteKit APIs while retaining the existing
+  gameplay lifecycle, scoring, collision, restart, and teardown contracts.
+- Set Swift 5 and iOS 12 as explicit project boundaries, refreshed the shared
+  schemes for Xcode 16.4, and pinned the hosted developer directory.
+- Replaced project-only parsing with a code-signing-disabled Debug application
+  build for a generic iOS Simulator destination whenever `xcodebuild` is
+  available.
+- Added static and mutation-sensitive contracts for the language mode,
+  deployment floor, modern callbacks and UIKit orientation properties, typed
+  scene loading, workflow pin, destination, signing suppression, and build
+  action.
+
+## Verification Completed
+
+- `sh -n scripts/check-baseline.sh scripts/build-app.sh build.sh` passed.
+- All four Make gates passed, and external-directory `make check` passed
+  through the absolute Makefile path.
+- Ruby project inspection confirmed Swift 5 and iOS 12 for both targets and
+  both Debug and Release configurations.
+- Ten isolated mutations were rejected, covering project settings, modern
+  source signatures, typed scene loading, workflow/build configuration, and
+  both UIKit orientation properties.
+- `git diff --check` and the exact diff, project structure, generated-artifact,
+  conflict-marker, executable-mode, and credential-shaped addition audits
+  passed.
+- `xcodebuild` was unavailable on Linux, so no local UIKit, SpriteKit,
+  simulator, rendering, touch, or gameplay-runtime result is claimed.
+- Exact implementation head
+  `a92e9258c804c4e3a83da8d30c296f31fe8decdb` compiled successfully with
+  Xcode 16.4 in push run `27718662618` and pull-request run `27718664377`.
+- PR #16 remained open and mergeable; no predecessor PR was merged or closed.
 
 ## Risks And Boundaries
 

--- a/docs/plans/2026-06-17-swift-xcode-build-modernization.md
+++ b/docs/plans/2026-06-17-swift-xcode-build-modernization.md
@@ -1,0 +1,159 @@
+---
+title: Modernize GameOfThrows for hosted Xcode builds
+type: modernization
+date: 2026-06-17
+status: planned
+execution: code
+---
+
+# Modernize GameOfThrows for hosted Xcode builds
+
+## Context
+
+The repository preserves a Swift 2-era SpriteKit sample, but its canonical
+`macos-15` workflow only parses the Xcode project. The current runner image uses
+Xcode 16.4 by default, while the app still uses Swift 2 method names, UIKit and
+SpriteKit APIs, project migration metadata, and iOS 9 deployment targets. A
+green workflow therefore does not prove that the application target compiles.
+
+The existing gameplay lifecycle stack is well covered by order-sensitive
+static contracts. The next engineering priority is to make those same sources
+compile on the maintained hosted Apple toolchain without changing gameplay.
+
+## Prioritized Engineering Tasks
+
+1. **Selected: restore a real hosted application build.** Modernize the Swift
+   syntax, project language mode, deployment floor, and maintenance gate so CI
+   compiles the app with Xcode 16.4.
+2. **Follow-up: execute the UI launch test on a pinned available simulator.**
+   Keep this separate because simulator availability and boot time have a
+   different reliability boundary from compilation.
+3. **Follow-up: extract deterministic gameplay policy tests.** Move collision,
+   scoring, and restart decisions behind Foundation-only seams before adding a
+   modern unit-test target.
+
+## Requirements
+
+- Convert `AppDelegate`, scene loading, SpriteKit lifecycle callbacks, action
+  APIs, geometry constructors, physics properties, touch handling, and the UI
+  launch test to Swift 5-compatible syntax.
+- Preserve the existing gameplay constants, contact pairing, scoring order,
+  pipe timing, restart behavior, teardown ordering, weak spawn ownership, and
+  keyed-action cancellation contracts.
+- Set an explicit Swift 5 language mode for both application and UI-test
+  targets.
+- Raise all iOS deployment targets from the unsupported iOS 9 range to iOS 12,
+  without changing device-family or signing assumptions.
+- Pin the hosted workflow to the installed Xcode 16.4 developer directory
+  instead of relying on the runner's mutable default selection.
+- When `xcodebuild` is available, make the maintained baseline perform a
+  code-signing-disabled Debug build of the `GameOfThrows` scheme for a generic
+  iOS Simulator destination rather than only listing the project.
+- Keep Linux verification truthful: syntax, source, project, documentation,
+  and mutation contracts run locally while the actual Apple build remains a
+  hosted macOS authority.
+- Update maintained guidance and change history for the new supported
+  toolchain and verification boundary.
+
+## Implementation Units
+
+### 1. Modernize application and UI-test sources
+
+Files:
+
+- `GameOfThrows/AppDelegate.swift`
+- `GameOfThrows/GameViewController.swift`
+- `GameOfThrows/GameScene.swift`
+- `GameOfThrowsUITests/GameOfThrowsUITests.swift`
+
+Adopt current Swift spellings and SpriteKit/UIKit signatures while retaining
+the existing class structure and behavior. Replace the custom keyed-unarchiver
+extension with SpriteKit's typed scene-file loading path. Keep optional-safe
+scene and view handling.
+
+### 2. Declare the maintained Xcode compatibility boundary
+
+Files:
+
+- `GameOfThrows.xcodeproj/project.pbxproj`
+- `GameOfThrows.xcodeproj/xcshareddata/xcschemes/GameOfThrows.xcscheme`
+- `GameOfThrows.xcodeproj/xcshareddata/xcschemes/GameOfThrowsUITests.xcscheme`
+
+Set Swift 5 language mode and iOS 12 deployment targets for both targets.
+Refresh migration metadata only where required for the current project format;
+do not reorder unrelated project objects or regenerate the project wholesale.
+
+### 3. Make compilation part of the canonical gate
+
+Files:
+
+- `scripts/check-baseline.sh`
+- `.github/workflows/check.yml`
+- `Makefile`
+
+Preserve the existing static baseline, select Xcode 16.4 in the hosted workflow,
+then run a bounded, code-signing-disabled application build against
+`generic/platform=iOS Simulator` whenever Xcode is installed. Add
+mutation-sensitive contracts for the Swift language mode, deployment floor,
+current callback spellings, typed scene loading, pinned developer directory,
+generic destination, and signing-disabled build.
+
+### 4. Update maintenance guidance and evidence
+
+Files:
+
+- `AGENTS.md`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+- `docs/plans/2026-06-17-swift-xcode-build-modernization.md`
+
+Document Xcode 16.4/Swift 5 compilation as the hosted baseline, retain the
+Linux limitation, and record only verification that actually ran.
+
+## Validation
+
+- Run `sh -n scripts/check-baseline.sh` and `sh -n build.sh`.
+- Run all four Make gates and external-directory `make check` on Linux, with a
+  truthful Xcode skip.
+- Reject isolated mutations to Swift 5 project settings, the iOS 12 floor,
+  modern SpriteKit callback names, typed scene loading, the generic simulator
+  destination, pinned Xcode developer directory, code-signing suppression, and
+  completed plan evidence.
+- Audit the exact diff, project-file structure, generated artifacts, conflict
+  markers, executable modes, and credential-shaped additions.
+- Require the canonical push and pull-request macOS jobs to compile the exact
+  delivery head successfully before recording terminal evidence.
+
+## Risks And Boundaries
+
+- Linux cannot compile UIKit or SpriteKit; hosted Xcode is the compilation
+  authority.
+- Raising the deployment floor drops iOS 9 through iOS 11 support. Those
+  releases are outside the current runner SDK's maintained compatibility
+  boundary.
+- A successful generic-simulator build proves source and project compilation,
+  not simulator launch, physics timing, rendering, touch behavior, or device
+  execution.
+- This change does not adopt Swift 6 language mode, strict concurrency,
+  SwiftUI, a new app lifecycle, or broad project regeneration.
+- PR stacking remains intact; no predecessor is merged or closed by this work.
+
+## Assumptions
+
+- The canonical `macos-15` runner continues to expose Xcode 16.4 at
+  `/Applications/Xcode_16.4.app` during this change.
+- The storyboard and `GameScene.sks` resources remain authoritative and load
+  through their existing target membership.
+- Existing static lifecycle contracts remain useful regression evidence during
+  the syntax migration and will be updated rather than weakened.
+
+## Primary References
+
+- GitHub Actions macOS 15 image inventory:
+  `https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md`
+- Apple `SKScene` lifecycle documentation:
+  `https://developer.apple.com/documentation/spritekit/skscene`
+- Apple `SKPhysicsContactDelegate` documentation:
+  `https://developer.apple.com/documentation/spritekit/skphysicscontactdelegate`

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+derived_data=$(mktemp -d "${TMPDIR:-/tmp}/gameofthrows-derived-data.XXXXXX")
+trap 'rm -rf -- "$derived_data"' EXIT HUP INT TERM
+
+xcodebuild \
+  -project "$ROOT_DIR/GameOfThrows.xcodeproj" \
+  -scheme GameOfThrows \
+  -configuration Debug \
+  -sdk iphonesimulator \
+  -destination 'generic/platform=iOS Simulator' \
+  -derivedDataPath "$derived_data" \
+  CODE_SIGNING_ALLOWED=NO \
+  build

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -23,8 +23,10 @@ TEARDOWN_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-teardown-death-rotation-
 LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-independent-make.md"
 UPDATE_ROTATION_PLAN="$ROOT_DIR/docs/plans/2026-06-14-update-rotation-ownership.md"
 UPDATE_ROTATION_CHECK="$ROOT_DIR/scripts/check-update-rotation-ownership.py"
+APP_BUILD_CHECK="$ROOT_DIR/scripts/build-app.sh"
 TEARDOWN_GAMEPLAY_PLAN="$ROOT_DIR/docs/plans/2026-06-16-teardown-gameplay-state.md"
 TEARDOWN_RESTART_PLAN="$ROOT_DIR/docs/plans/2026-06-16-teardown-restart-revocation.md"
+SWIFT_MODERNIZATION_PLAN="$ROOT_DIR/docs/plans/2026-06-17-swift-xcode-build-modernization.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 PROJECT_FILE="$ROOT_DIR/GameOfThrows.xcodeproj/project.pbxproj"
 SHARED_SCHEMES="$ROOT_DIR/GameOfThrows.xcodeproj/xcshareddata/xcschemes"
@@ -59,6 +61,7 @@ for path in \
   "GameOfThrowsUITests/Info.plist" \
   "GameOfThrowsUITests/GameOfThrowsUITests.swift" \
   "scripts/check-update-rotation-ownership.py" \
+  "scripts/build-app.sh" \
   "docs/plans/2026-06-14-update-rotation-ownership.md" \
   "docs/plans/2026-06-09-score-label-restart-reset.md" \
   "docs/plans/2026-06-09-contact-resource-guard.md" \
@@ -84,6 +87,7 @@ require_file "docs/plans/2026-06-13-teardown-death-rotation-cancellation.md"
 require_file "docs/plans/2026-06-13-location-independent-make.md"
 require_file "docs/plans/2026-06-16-teardown-gameplay-state.md"
 require_file "docs/plans/2026-06-16-teardown-restart-revocation.md"
+require_file "docs/plans/2026-06-17-swift-xcode-build-modernization.md"
 
 python3 "$UPDATE_ROTATION_CHECK" \
   "$ROOT_DIR/GameOfThrows/GameScene.swift" \
@@ -111,6 +115,94 @@ if ! grep -Eq '^\.PHONY: .*build.*check.*lint.*test|^\.PHONY: .*build.*lint.*tes
   exit 1
 fi
 
+python3 - \
+  "$ROOT_DIR/GameOfThrows/AppDelegate.swift" \
+  "$ROOT_DIR/GameOfThrows/GameViewController.swift" \
+  "$ROOT_DIR/GameOfThrows/GameScene.swift" \
+  "$ROOT_DIR/GameOfThrowsUITests/GameOfThrowsUITests.swift" \
+  "$PROJECT_FILE" \
+  "$CI_WORKFLOW" \
+  "$APP_BUILD_CHECK" <<'PY'
+import sys
+from pathlib import Path
+
+app_delegate, view_controller, scene, ui_tests, project, workflow, app_build = (
+    Path(path).read_text(encoding="utf-8") for path in sys.argv[1:]
+)
+
+source_contracts = (
+    (app_delegate, "@main"),
+    (app_delegate, "didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?"),
+    (view_controller, 'GameScene(fileNamed: "GameScene")'),
+    (view_controller, "guard let skView = view as? SKView"),
+    (scene, "override func didMove(to view: SKView)"),
+    (scene, "override func willMove(from view: SKView)"),
+    (scene, "override func update(_ currentTime: TimeInterval)"),
+    (scene, "func didBegin(_ contact: SKPhysicsContact)"),
+    (scene, "override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?)"),
+    (ui_tests, "app = XCUIApplication()"),
+    (ui_tests, "XCTAssertTrue(app.exists)"),
+)
+if any(value not in source for source, value in source_contracts):
+    raise SystemExit("Swift 5 source and SpriteKit lifecycle contracts are incomplete.")
+
+legacy_spellings = (
+    "@UIApplicationMain",
+    "didMoveToView",
+    "willMoveFromView",
+    "didBeginContact",
+    "removeActionForKey",
+    "runAction",
+    "CGVectorMake",
+    "CGPointMake",
+    "CGSizeMake",
+    "repeatActionForever",
+    "runBlock",
+    "waitForDuration",
+    "animateWithTextures",
+    "rotateByAngle",
+    "NSTimeInterval",
+    "NSInteger",
+)
+all_swift = "\n".join((app_delegate, view_controller, scene, ui_tests))
+if any(value in all_swift for value in legacy_spellings):
+    raise SystemExit("Swift 2 source spellings must not return to the maintained targets.")
+
+if project.count("SWIFT_VERSION = 5.0;") != 4:
+    raise SystemExit("Application and UI-test Debug/Release configurations must use Swift 5.")
+if project.count("IPHONEOS_DEPLOYMENT_TARGET = 12.0;") != 6:
+    raise SystemExit("All project and target configurations must retain the iOS 12 deployment floor.")
+if "IPHONEOS_DEPLOYMENT_TARGET = 9." in project:
+    raise SystemExit("Unsupported iOS 9 deployment targets must not return.")
+
+developer_dir = "DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer"
+if workflow.count(developer_dir) != 1:
+    raise SystemExit("Hosted validation must pin the installed Xcode 16.4 developer directory.")
+
+build_contracts = (
+    'xcodebuild \\\n',
+    '-project "$ROOT_DIR/GameOfThrows.xcodeproj"',
+    "-scheme GameOfThrows",
+    "-configuration Debug",
+    "-sdk iphonesimulator",
+    "-destination 'generic/platform=iOS Simulator'",
+    'CODE_SIGNING_ALLOWED=NO',
+    'mktemp -d "${TMPDIR:-/tmp}/gameofthrows-derived-data.XXXXXX"',
+    "  build\n",
+)
+if any(value not in app_build for value in build_contracts):
+    raise SystemExit("The maintained Xcode gate must perform an isolated signing-disabled simulator build.")
+PY
+
+if ! grep -Fq "hosted Xcode 16.4 application build" "$ROOT_DIR/AGENTS.md" ||
+  ! grep -Fq "generic iOS Simulator destination with code signing disabled" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "code-signing-disabled Swift 5 application build with pinned Xcode 16.4" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "Swift 5, iOS 12, and hosted Xcode 16.4 build boundary" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "Migrated the app and UI launch test from Swift 2-era syntax to Swift 5" "$ROOT_DIR/CHANGES.md"; then
+  printf '%s\n' "Project guidance must document the maintained Swift 5 and hosted Xcode build boundary." >&2
+  exit 1
+fi
+
 python3 - "$ROOT_DIR/GameOfThrows/GameScene.swift" <<'PY'
 import sys
 from pathlib import Path
@@ -122,55 +214,55 @@ rotation_helper = source[
 ]
 presentation_helper = source[
     source.index("func resetScenePresentation"):
-    source.index("override func didMoveToView")
+    source.index("override func didMove(to view: SKView)")
 ]
 presentation = source[
-    source.index("override func didMoveToView"):
-    source.index("override func willMoveFromView")
+    source.index("override func didMove(to view: SKView)"):
+    source.index("override func willMove(from view: SKView)")
 ]
 teardown = source[
-    source.index("override func willMoveFromView"):
+    source.index("override func willMove(from view: SKView)"):
     source.index("func spawnPipes")
 ]
 cancel_rotation_helper = "cancelBirdDeathRotation()"
-optional_rotation_cancel = 'bird?.removeActionForKey("deathRotation")'
+optional_rotation_cancel = 'bird?.removeAction(forKey: "deathRotation")'
 if rotation_helper.count(optional_rotation_cancel) != 1:
     raise SystemExit("Bird death rotation helper must cancel the keyed action exactly once when present.")
 if presentation_helper.count(cancel_rotation_helper) != 1:
     raise SystemExit("Scene presentation reset must cancel bird death rotation exactly once.")
-if presentation_helper.index(cancel_rotation_helper) > presentation_helper.index("self.removeAllChildren()"):
+if presentation_helper.index(cancel_rotation_helper) > presentation_helper.index("removeAllChildren()"):
     raise SystemExit("Scene presentation reset must cancel bird death rotation before child cleanup.")
 if teardown.count(cancel_rotation_helper) != 1:
     raise SystemExit("View teardown must cancel bird death rotation exactly once.")
-if teardown.index(cancel_rotation_helper) > teardown.index("self.physicsWorld.contactDelegate = nil"):
+if teardown.index(cancel_rotation_helper) > teardown.index("physicsWorld.contactDelegate = nil"):
     raise SystemExit("View teardown must cancel bird death rotation before contact delegate cleanup.")
 presentation_required = (
-    'self.removeActionForKey("spawnPipes")',
-    'self.removeActionForKey("flash")',
-    "self.removeAllChildren()",
+    'removeAction(forKey: "spawnPipes")',
+    'removeAction(forKey: "flash")',
+    "removeAllChildren()",
 )
 if any(presentation_helper.count(item) != 1 for item in presentation_required):
     raise SystemExit("Scene presentation reset must remove keyed actions and prior children.")
 if presentation.count("resetScenePresentation()") != 1:
-    raise SystemExit("didMoveToView must reset prior scene presentation state exactly once.")
+    raise SystemExit("didMove(to:) must reset prior scene presentation state exactly once.")
 if presentation.index("resetScenePresentation()") > presentation.index("canRestart = false"):
     raise SystemExit("Scene presentation reset must run before gameplay setup begins.")
 
 restart = source[
-    source.index("func resetScene"):
+    source.index("func resetScene()"):
     source.index("override func touchesBegan")
 ]
-collision = source[source.index("func didBeginContact"):]
-cancel_rotation = 'bird.removeActionForKey("deathRotation")'
-bird_reset = "bird.position = CGPointMake"
+collision = source[source.index("func didBegin(_ contact: SKPhysicsContact)"):]
+cancel_rotation = 'bird.removeAction(forKey: "deathRotation")'
+bird_reset = "bird.position = CGPoint("
 if restart.count(cancel_rotation) != 1:
     raise SystemExit("Restart must cancel the prior keyed death rotation exactly once.")
 if restart.index(cancel_rotation) > restart.index(bird_reset):
     raise SystemExit("Restart must cancel the death rotation before restoring bird state.")
 death_rotation_required = (
-    "let deathRotation = SKAction.rotateByAngle",
-    "let stopBird = SKAction.runBlock({ bird.speed = 0 })",
-    'bird.runAction(SKAction.sequence([deathRotation, stopBird]), withKey: "deathRotation")',
+    "let deathRotation = SKAction.rotate(byAngle:",
+    "let stopBird = SKAction.run { bird.speed = 0 }",
+    'bird.run(SKAction.sequence([deathRotation, stopBird]), withKey: "deathRotation")',
 )
 if any(collision.count(item) != 1 for item in death_rotation_required):
     raise SystemExit("Fatal collision rotation must remain one keyed stop sequence.")
@@ -178,7 +270,7 @@ if "completion:{bird.speed = 0 }" in collision:
     raise SystemExit("Fatal collision rotation must not retain an unkeyed late completion.")
 
 required = (
-    "func isBirdCollisionContact(contact: SKPhysicsContact) -> Bool",
+    "func isBirdCollisionContact(_ contact: SKPhysicsContact) -> Bool",
     "let bodyAIsObstacle = bodyMatchesCategory(contact.bodyA, category: worldCategory) ||",
     "bodyMatchesCategory(contact.bodyA, category: pipeCategory)",
     "let bodyBIsObstacle = bodyMatchesCategory(contact.bodyB, category: worldCategory) ||",
@@ -201,10 +293,16 @@ if "scoreCategory" in helper:
 PY
 
 sh -n "$ROOT_DIR/build.sh"
+sh -n "$APP_BUILD_CHECK"
 sh -n "$ROOT_DIR/scripts/check-baseline.sh"
 
 if [ ! -x "$ROOT_DIR/build.sh" ]; then
   printf '%s\n' "build.sh must be executable." >&2
+  exit 1
+fi
+
+if [ ! -x "$APP_BUILD_CHECK" ]; then
+  printf '%s\n' "scripts/build-app.sh must be executable." >&2
   exit 1
 fi
 
@@ -245,8 +343,9 @@ for image_name in "bird-01" "bird-02" "sky" "land" "PipeUp" "PipeDown"; do
 done
 
 if ! grep -Fq "func testApplicationLaunches" "$ROOT_DIR/GameOfThrowsUITests/GameOfThrowsUITests.swift" ||
-  ! grep -Fq "XCUIApplication().launch()" "$ROOT_DIR/GameOfThrowsUITests/GameOfThrowsUITests.swift" ||
-  ! grep -Fq "XCTAssertTrue(XCUIApplication().exists)" "$ROOT_DIR/GameOfThrowsUITests/GameOfThrowsUITests.swift"; then
+  ! grep -Fq "app = XCUIApplication()" "$ROOT_DIR/GameOfThrowsUITests/GameOfThrowsUITests.swift" ||
+  ! grep -Fq "app.launch()" "$ROOT_DIR/GameOfThrowsUITests/GameOfThrowsUITests.swift" ||
+  ! grep -Fq "XCTAssertTrue(app.exists)" "$ROOT_DIR/GameOfThrowsUITests/GameOfThrowsUITests.swift"; then
   printf '%s\n' "UI tests must keep a launch smoke test." >&2
   exit 1
 fi
@@ -258,8 +357,8 @@ if ! grep -Fq "IOS_DESTINATION" "$ROOT_DIR/build.sh" ||
   exit 1
 fi
 
-if ! grep -Fq "guard let path" "$ROOT_DIR/GameOfThrows/GameViewController.swift" ||
-  ! grep -Fq "as? SKView" "$ROOT_DIR/GameOfThrows/GameViewController.swift"; then
+if ! grep -Fq 'let scene = GameScene(fileNamed: "GameScene")' "$ROOT_DIR/GameOfThrows/GameViewController.swift" ||
+  ! grep -Fq "guard let skView = view as? SKView" "$ROOT_DIR/GameOfThrows/GameViewController.swift"; then
   printf '%s\n' "Scene loading and SKView access must stay optional-safe." >&2
   exit 1
 fi
@@ -272,7 +371,7 @@ if ! grep -Fq "arc4random_uniform(height)" "$ROOT_DIR/GameOfThrows/GameScene.swi
 fi
 
 if ! grep -Fq "func applyBirdImpulse" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
-  ! grep -Fq "physicsBody.applyImpulse(CGVectorMake(0, 30))" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
+  ! grep -Fq "physicsBody.applyImpulse(CGVector(dx: 0, dy: 30))" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
   grep -Fq "for touch" "$ROOT_DIR/GameOfThrows/GameScene.swift"; then
   printf '%s\n' "Touch handling must use the single guarded bird impulse helper." >&2
   exit 1
@@ -315,7 +414,7 @@ if ! grep -Fq "scoreLabelNode.setScale(1.0)" "$ROOT_DIR/GameOfThrows/GameScene.s
 fi
 
 if ! grep -Fq "let skyColor = skyColor" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
-  ! grep -Fq "let stopBird = SKAction.runBlock({ bird.speed = 0 })" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
+  ! grep -Fq "let stopBird = SKAction.run { bird.speed = 0 }" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
   ! grep -Fq "self.backgroundColor = skyColor" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
   grep -Fq "self.bird.speed = 0" "$ROOT_DIR/GameOfThrows/GameScene.swift"; then
   printf '%s\n' "GameScene contact handling must guard required scene resources and avoid delayed self.bird access." >&2
@@ -324,9 +423,9 @@ fi
 
 if ! grep -Fq "[weak self] in self?.spawnPipes()" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
   ! grep -Fq 'withKey: "spawnPipes"' "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
-  ! grep -Fq "override func willMoveFromView" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
-  ! grep -Fq 'removeActionForKey("spawnPipes")' "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
-  ! grep -Fq 'removeActionForKey("flash")' "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
+  ! grep -Fq "override func willMove(from view: SKView)" "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
+  ! grep -Fq 'removeAction(forKey: "spawnPipes")' "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
+  ! grep -Fq 'removeAction(forKey: "flash")' "$ROOT_DIR/GameOfThrows/GameScene.swift" ||
   ! grep -Fq "physicsWorld.contactDelegate = nil" "$ROOT_DIR/GameOfThrows/GameScene.swift"; then
   printf '%s\n' "GameScene must release repeating actions and contact callbacks when leaving its view." >&2
   exit 1
@@ -337,15 +436,15 @@ import sys
 from pathlib import Path
 
 source = Path(sys.argv[1]).read_text()
-teardown = source.split("override func willMoveFromView", 1)[-1].split(
+teardown = source.split("override func willMove(from view: SKView)", 1)[-1].split(
     "func spawnPipes", 1
 )[0]
 contracts = (
     "canRestart = false",
     "moving?.speed = 0",
     "cancelBirdDeathRotation()",
-    'removeActionForKey("spawnPipes")',
-    'removeActionForKey("flash")',
+    'removeAction(forKey: "spawnPipes")',
+    'removeAction(forKey: "flash")',
     "physicsWorld.contactDelegate = nil",
 )
 if any(teardown.count(contract) != 1 for contract in contracts):
@@ -505,9 +604,9 @@ if ! grep -Fq "make check" "$CONTACT_RESOURCE_PLAN"; then
 fi
 
 if command -v xcodebuild >/dev/null 2>&1; then
-  xcodebuild -list -project "$ROOT_DIR/GameOfThrows.xcodeproj" >/dev/null
+  "$APP_BUILD_CHECK"
 else
-  printf '%s\n' "xcodebuild not found; static GameOfThrows baseline checks passed."
+  printf '%s\n' "xcodebuild not found; Swift/Xcode application build skipped after static GameOfThrows baseline checks passed."
 fi
 
 workflow_files=$(find "$ROOT_DIR/.github/workflows" -type f -print)
@@ -537,12 +636,14 @@ jobs:
   check:
     runs-on: macos-15
     timeout-minutes: 10
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
     steps:
       - name: Check out repository
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
-      - name: Run static project baseline
+      - name: Run project baseline
         run: make check
 EOF
 

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -358,8 +358,10 @@ if ! grep -Fq "IOS_DESTINATION" "$ROOT_DIR/build.sh" ||
 fi
 
 if ! grep -Fq 'let scene = GameScene(fileNamed: "GameScene")' "$ROOT_DIR/GameOfThrows/GameViewController.swift" ||
-  ! grep -Fq "guard let skView = view as? SKView" "$ROOT_DIR/GameOfThrows/GameViewController.swift"; then
-  printf '%s\n' "Scene loading and SKView access must stay optional-safe." >&2
+  ! grep -Fq "guard let skView = view as? SKView" "$ROOT_DIR/GameOfThrows/GameViewController.swift" ||
+  ! grep -Fq "override var shouldAutorotate: Bool" "$ROOT_DIR/GameOfThrows/GameViewController.swift" ||
+  ! grep -Fq "override var supportedInterfaceOrientations: UIInterfaceOrientationMask" "$ROOT_DIR/GameOfThrows/GameViewController.swift"; then
+  printf '%s\n' "Scene loading, SKView access, and UIKit orientation overrides must stay modern and optional-safe." >&2
   exit 1
 fi
 

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -920,3 +920,35 @@ if (
         "Teardown restart revocation plan must record completed status, actual verification, and the runtime boundary."
     )
 PY
+
+python3 - "$SWIFT_MODERNIZATION_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+normalized_verification = " ".join(verification.split())
+required = (
+    "All four Make gates passed",
+    "external-directory `make check` passed",
+    "Ten isolated mutations were rejected",
+    "`xcodebuild` was unavailable on Linux",
+    "no local UIKit, SpriteKit, simulator, rendering, touch, or gameplay-runtime result is claimed",
+    "`a92e9258c804c4e3a83da8d30c296f31fe8decdb`",
+    "push run `27718662618`",
+    "pull-request run `27718664377`",
+    "PR #16 remained open and mergeable",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in normalized_verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Swift/Xcode modernization plan must record completed status, actual hosted evidence, and the runtime boundary."
+    )
+PY

--- a/scripts/check-update-rotation-ownership.py
+++ b/scripts/check-update-rotation-ownership.py
@@ -7,8 +7,8 @@ source = Path(sys.argv[1]).read_text(encoding="utf-8")
 plan = Path(sys.argv[2]).read_text(encoding="utf-8")
 baseline = Path(sys.argv[3]).read_text(encoding="utf-8")
 
-start = source.find("override func update(currentTime: CFTimeInterval)")
-end = source.find("\n    func didBeginContact", start)
+start = source.find("override func update(_ currentTime: TimeInterval)")
+end = source.find("\n    func didBegin(_ contact: SKPhysicsContact)", start)
 if start == -1 or end == -1:
     raise SystemExit("GameScene update boundary is missing.")
 
@@ -19,7 +19,7 @@ gameplay_guard = """if !isGameplayRunning() {
 guard_index = update.find(gameplay_guard)
 physics_index = update.find("guard let bird = bird, let physicsBody = bird.physicsBody")
 velocity_index = update.find("let verticalVelocity = physicsBody.velocity.dy")
-rotation_index = update.find("bird.zRotation = self.clamp(")
+rotation_index = update.find("bird.zRotation = clamp(")
 if -1 in (guard_index, physics_index, velocity_index, rotation_index):
     raise SystemExit("GameScene update rotation ownership contract is incomplete.")
 if not guard_index < physics_index < velocity_index < rotation_index:


### PR DESCRIPTION
## Summary

GameOfThrows now has a maintained Apple compilation boundary instead of a green workflow that only proves the legacy project can be parsed. The app and UI-test sources use Swift 5-compatible UIKit and SpriteKit APIs, both targets declare an iOS 12 floor, and the canonical macOS gate builds the application with pinned Xcode 16.4.

## Baseline

The preserved project used Swift 2 syntax and legacy UIKit/SpriteKit API spellings, while hosted CI only parsed the Xcode project and could not prove the application compiled. The first hosted build on this branch exposed two remaining Swift 5 import changes: `shouldAutorotate` and `supportedInterfaceOrientations` are overriding properties rather than methods.

## Improvements

- Modernized the app and UI-test targets to Swift 5 while preserving the existing SpriteKit gameplay and lifecycle behavior.
- Raised both targets to an iOS 12 deployment floor and pinned hosted compilation to Xcode 16.4.
- Loads `GameScene.sks` through `GameScene(fileNamed:)` and keeps scene/view access optional-safe.
- Builds for `generic/platform=iOS Simulator` with code signing disabled and isolated temporary DerivedData.
- Corrected the UIKit orientation overrides to Swift properties and added static regression checks for both declarations.

## Validation

- `sh -n scripts/check-baseline.sh scripts/build-app.sh build.sh` passed.
- `make lint`, `make test`, `make build`, and `make check` passed on Linux; Xcode compilation was explicitly skipped because `xcodebuild` is unavailable.
- External-directory `make check` through the absolute Makefile path passed.
- Xcode project parsing confirmed Swift 5.0 and iOS 12.0 for both targets in Debug and Release.
- Eight isolated baseline mutations were rejected, covering language mode, deployment floor, lifecycle spelling, typed scene loading, Xcode pinning, destination, code-signing suppression, and final build execution.
- Exact diff, generated-artifact, conflict-marker, executable-mode, and tracked secret-pattern audits passed.
- The first hosted Xcode run failed on method-form orientation overrides; commit `a92e9258c804c4e3a83da8d30c296f31fe8decdb` applies the property-form fix, and both its push and pull-request Xcode runs passed.
- Commit `7bce634c511a32bb001d873194a0c5b3da839ae0` records those hosted run identifiers and the Linux runtime boundary in the modernization plan, with a regression check that rejects stale or incomplete verification evidence. Its exact-head push run `27718897089` and pull-request run `27718900016` both completed successfully.

## Risk

This is a broad language and project modernization for a historical iOS sample. Local Linux validation cannot compile UIKit or SpriteKit, and no simulator launch, UI test, signing flow, or device behavior was exercised. The generic-simulator hosted build is the required compilation boundary; runtime behavior still requires a compatible Apple environment.

## Follow-Ups

- Run simulator launch and UI tests on a maintained Apple runner once their runtime reliability boundary is designed separately from compilation.
- Monitor the Check workflow for Xcode image or SDK drift after merge; a missing Xcode 16.4 image or renewed Swift migration failure is the rollback/mitigation trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)

